### PR TITLE
Normalize histogram mode features before binning

### DIFF
--- a/Catch22Sharp/DN_HistogramMode_10.cs
+++ b/Catch22Sharp/DN_HistogramMode_10.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace Catch22Sharp
+{
+    public static partial class Catch22
+    {
+        public static double DN_HistogramMode_10(Span<double> y)
+        {
+            for (int i = 0; i < y.Length; i++)
+            {
+                if (double.IsNaN(y[i]))
+                {
+                    return double.NaN;
+                }
+            }
+
+            const int nBins = 10;
+
+            double minVal = Stats.min_(y);
+            double maxVal = Stats.max_(y);
+            if (maxVal == minVal)
+            {
+                return minVal;
+            }
+
+            double[] yZscored = new double[y.Length];
+            Stats.zscore_norm2(y, yZscored.AsSpan());
+            Span<double> yWork = yZscored;
+
+            double minZ = Stats.min_(yWork);
+            double maxZ = Stats.max_(yWork);
+            double binStep = (maxZ - minZ) / nBins;
+            int[] histCounts = new int[nBins];
+            double[] binEdges = new double[nBins + 1];
+
+            for (int i = 0; i < yWork.Length; i++)
+            {
+                double value = yWork[i];
+                int binInd = (int)((value - minZ) / binStep);
+                if (binInd < 0)
+                {
+                    binInd = 0;
+                }
+                if (binInd >= nBins)
+                {
+                    binInd = nBins - 1;
+                }
+                histCounts[binInd] += 1;
+            }
+
+            for (int i = 0; i < nBins + 1; i++)
+            {
+                binEdges[i] = i * binStep + minZ;
+            }
+
+            double maxCount = 0;
+            int numMaxs = 1;
+            double outputValue = 0;
+            for (int i = 0; i < nBins; i++)
+            {
+                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
+                if (histCounts[i] > maxCount)
+                {
+                    maxCount = histCounts[i];
+                    numMaxs = 1;
+                    outputValue = binMean;
+                }
+                else if (histCounts[i] == maxCount)
+                {
+                    numMaxs += 1;
+                    outputValue += binMean;
+                }
+            }
+
+            return outputValue / numMaxs;
+        }
+    }
+}

--- a/Catch22Sharp/DN_HistogramMode_5.cs
+++ b/Catch22Sharp/DN_HistogramMode_5.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace Catch22Sharp
+{
+    public static partial class Catch22
+    {
+        public static double DN_HistogramMode_5(Span<double> y)
+        {
+            for (int i = 0; i < y.Length; i++)
+            {
+                if (double.IsNaN(y[i]))
+                {
+                    return double.NaN;
+                }
+            }
+
+            const int nBins = 5;
+
+            double minVal = Stats.min_(y);
+            double maxVal = Stats.max_(y);
+            if (maxVal == minVal)
+            {
+                return minVal;
+            }
+
+            double[] yZscored = new double[y.Length];
+            Stats.zscore_norm2(y, yZscored.AsSpan());
+            Span<double> yWork = yZscored;
+
+            double minZ = Stats.min_(yWork);
+            double maxZ = Stats.max_(yWork);
+            double binStep = (maxZ - minZ) / nBins;
+            int[] histCounts = new int[nBins];
+            double[] binEdges = new double[nBins + 1];
+
+            for (int i = 0; i < yWork.Length; i++)
+            {
+                double value = yWork[i];
+                int binInd = (int)((value - minZ) / binStep);
+                if (binInd < 0)
+                {
+                    binInd = 0;
+                }
+                if (binInd >= nBins)
+                {
+                    binInd = nBins - 1;
+                }
+                histCounts[binInd] += 1;
+            }
+
+            for (int i = 0; i < nBins + 1; i++)
+            {
+                binEdges[i] = i * binStep + minZ;
+            }
+
+            double maxCount = 0;
+            int numMaxs = 1;
+            double outputValue = 0;
+            for (int i = 0; i < nBins; i++)
+            {
+                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
+                if (histCounts[i] > maxCount)
+                {
+                    maxCount = histCounts[i];
+                    numMaxs = 1;
+                    outputValue = binMean;
+                }
+                else if (histCounts[i] == maxCount)
+                {
+                    numMaxs += 1;
+                    outputValue += binMean;
+                }
+            }
+
+            return outputValue / numMaxs;
+        }
+    }
+}

--- a/Catch22SharpTest/DN_HistogramMode_10.cs
+++ b/Catch22SharpTest/DN_HistogramMode_10.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class DN_HistogramMode_10_Tests
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.DN_HistogramMode_10(TestData.Test1);
+            var expected = TestData.Test1Output["DN_HistogramMode_10"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.DN_HistogramMode_10(TestData.Test2);
+            var expected = TestData.Test2Output["DN_HistogramMode_10"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.DN_HistogramMode_10(TestData.TestShort);
+            var expected = TestData.TestShortOutput["DN_HistogramMode_10"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.DN_HistogramMode_10(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["DN_HistogramMode_10"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+    }
+}

--- a/Catch22SharpTest/DN_HistogramMode_5.cs
+++ b/Catch22SharpTest/DN_HistogramMode_5.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class DN_HistogramMode_5_Tests
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.DN_HistogramMode_5(TestData.Test1);
+            var expected = TestData.Test1Output["DN_HistogramMode_5"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.DN_HistogramMode_5(TestData.Test2);
+            var expected = TestData.Test2Output["DN_HistogramMode_5"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.DN_HistogramMode_5(TestData.TestShort);
+            var expected = TestData.TestShortOutput["DN_HistogramMode_5"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.DN_HistogramMode_5(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["DN_HistogramMode_5"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- z-score inputs before computing DN_HistogramMode_5 and DN_HistogramMode_10 to mirror the reference pipeline
- reuse shared stats helpers while keeping the existing NaN and constant-series handling intact
- restore the histogram mode expectations in the test fixtures to their original reference values

## Testing
- dotnet test Catch22Sharp.sln

------
https://chatgpt.com/codex/tasks/task_e_68da36cedccc8326bc844daed782091b