### PR TITLE
Port FFT utilities and refactor time-series features

### DIFF
--- a/Catch22Sharp/DN_HistogramMode_10.cs
+++ b/Catch22Sharp/DN_HistogramMode_10.cs
@@ -31,12 +31,16 @@ namespace Catch22Sharp
             double[] binEdges = new double[nBins + 1];
             HistCounts.histcounts_preallocated(yWork, nBins, histCounts.AsSpan(), binEdges.AsSpan());
 
+            double binStep = nBins > 0 ? binEdges[1] - binEdges[0] : 0.0;
+            double[] binCenters = new double[nBins];
+            HelperFunctions.linspace(binEdges[0] + binStep / 2.0, binEdges[nBins] - binStep / 2.0, nBins, binCenters.AsSpan());
+
             double maxCount = 0;
             int numMaxs = 1;
             double outputValue = 0;
             for (int i = 0; i < nBins; i++)
             {
-                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
+                double binMean = binCenters[i];
                 if (histCounts[i] > maxCount)
                 {
                     maxCount = histCounts[i];

--- a/Catch22Sharp/DN_HistogramMode_5.cs
+++ b/Catch22Sharp/DN_HistogramMode_5.cs
@@ -31,12 +31,16 @@ namespace Catch22Sharp
             double[] binEdges = new double[nBins + 1];
             HistCounts.histcounts_preallocated(yWork, nBins, histCounts.AsSpan(), binEdges.AsSpan());
 
+            double binStep = nBins > 0 ? binEdges[1] - binEdges[0] : 0.0;
+            double[] binCenters = new double[nBins];
+            HelperFunctions.linspace(binEdges[0] + binStep / 2.0, binEdges[nBins] - binStep / 2.0, nBins, binCenters.AsSpan());
+
             double maxCount = 0;
             int numMaxs = 1;
             double outputValue = 0;
             for (int i = 0; i < nBins; i++)
             {
-                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
+                double binMean = binCenters[i];
                 if (histCounts[i] > maxCount)
                 {
                     maxCount = histCounts[i];

--- a/Catch22Sharp/fft.cs
+++ b/Catch22Sharp/fft.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Numerics;
+
+namespace Catch22Sharp
+{
+    public static class Fft
+    {
+        public static void twiddles(Span<Complex> a)
+        {
+            double pi = Math.PI;
+            int size = a.Length;
+            for (int i = 0; i < size; i++)
+            {
+                double angle = -pi * i / size;
+                a[i] = Complex.Exp(new Complex(0.0, angle));
+            }
+        }
+
+        private static void RecursiveFft(Complex[] a, Complex[] outBuf, int size, int step, Complex[] tw, int aOffset, int outOffset)
+        {
+            if (step < size)
+            {
+                RecursiveFft(outBuf, a, size, step * 2, tw, outOffset, aOffset);
+                RecursiveFft(outBuf, a, size, step * 2, tw, outOffset + step, aOffset + step);
+
+                for (int i = 0; i < size; i += 2 * step)
+                {
+                    int outIndex = outOffset + i;
+                    Complex t = tw[i] * outBuf[outIndex + step];
+                    a[aOffset + i / 2] = outBuf[outIndex] + t;
+                    a[aOffset + (i + size) / 2] = outBuf[outIndex] - t;
+                }
+            }
+        }
+
+        public static void fft(Span<Complex> a, Span<Complex> tw)
+        {
+            int size = a.Length;
+            Complex[] aArray = a.ToArray();
+            Complex[] outArray = new Complex[size];
+            Array.Copy(aArray, outArray, size);
+            Complex[] twArray = tw.ToArray();
+            RecursiveFft(aArray, outArray, size, 1, twArray, 0, 0);
+            for (int i = 0; i < size; i++)
+            {
+                a[i] = aArray[i];
+            }
+        }
+    }
+}

--- a/Catch22Sharp/helper_functions.cs
+++ b/Catch22Sharp/helper_functions.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace Catch22Sharp
+{
+    public static class HelperFunctions
+    {
+        public static void sort(Span<double> values)
+        {
+            double[] copy = values.ToArray();
+            Array.Sort(copy);
+            copy.AsSpan().CopyTo(values);
+        }
+
+        public static void linspace(double start, double end, int numGroups, Span<double> output)
+        {
+            if (numGroups <= 0)
+            {
+                return;
+            }
+
+            double stepSize = numGroups == 1 ? 0.0 : (end - start) / (numGroups - 1);
+            for (int i = 0; i < numGroups; i++)
+            {
+                output[i] = start;
+                start += stepSize;
+            }
+        }
+
+        public static double quantile(Span<double> values, double quant)
+        {
+            int size = values.Length;
+            if (size == 0)
+            {
+                return double.NaN;
+            }
+
+            double[] tmp = values.ToArray();
+            Array.Sort(tmp);
+
+            double q = 0.5 / size;
+            if (quant < q)
+            {
+                return tmp[0];
+            }
+
+            if (quant > 1 - q)
+            {
+                return tmp[size - 1];
+            }
+
+            double quantIdx = size * quant - 0.5;
+            int idxLeft = (int)Math.Floor(quantIdx);
+            int idxRight = (int)Math.Ceiling(quantIdx);
+            if (idxRight == idxLeft)
+            {
+                return tmp[idxLeft];
+            }
+
+            double value = tmp[idxLeft] + (quantIdx - idxLeft) * (tmp[idxRight] - tmp[idxLeft]) / (idxRight - idxLeft);
+            return value;
+        }
+
+        public static void binarize(Span<double> input, Span<int> output, string how)
+        {
+            double threshold = 0.0;
+            if (how == "mean")
+            {
+                threshold = Stats.mean(input);
+            }
+            else if (how == "median")
+            {
+                threshold = Stats.median(input);
+            }
+
+            for (int i = 0; i < input.Length && i < output.Length; i++)
+            {
+                output[i] = input[i] > threshold ? 1 : 0;
+            }
+        }
+
+        public static double f_entropy(Span<double> input)
+        {
+            double entropy = 0.0;
+            for (int i = 0; i < input.Length; i++)
+            {
+                double value = input[i];
+                if (value > 0)
+                {
+                    entropy += value * Math.Log(value);
+                }
+            }
+
+            return -entropy;
+        }
+
+        public static void subset(Span<int> input, int start, int end, Span<int> output)
+        {
+            int j = 0;
+            for (int i = start; i < end && j < output.Length; i++)
+            {
+                output[j++] = input[i];
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port the C FFT routines into a C# utility and expose helper functions translated from helper_functions.c
- update CO_AutoCorr to reuse the FFT-based autocorrelation pipeline and share quantile helpers in the outlier metrics
- reuse helper linspace/quantile logic inside the histogram-mode features to keep implementations consistent

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68da962cef7883269c39aa2f560e22ae