### PR TITLE
Add tests for CO metrics and normalize implementations

### DIFF
--- a/Catch22Sharp/CO_AutoCorr.cs
+++ b/Catch22Sharp/CO_AutoCorr.cs
@@ -283,10 +283,14 @@ namespace Catch22Sharp
                 return 0.0;
             }
 
-            double[] diffTemp = new double[y.Length - tau];
-            for (int i = 0; i < y.Length - tau; i++)
+            double[] yZscored = new double[y.Length];
+            Stats.zscore_norm2(y, yZscored);
+            Span<double> yWork = yZscored;
+
+            double[] diffTemp = new double[yWork.Length - tau];
+            for (int i = 0; i < yWork.Length - tau; i++)
             {
-                diffTemp[i] = Math.Pow(y[i + 1] - y[i], 3);
+                diffTemp[i] = Math.Pow(yWork[i + 1] - yWork[i], 3);
             }
 
             return Stats.mean(diffTemp);
@@ -309,17 +313,21 @@ namespace Catch22Sharp
                 return 0.0;
             }
 
-            int length = y.Length - tau;
+            double[] yZscored = new double[y.Length];
+            Stats.zscore_norm2(y, yZscored);
+            Span<double> yWork = yZscored;
+
+            int length = yWork.Length - tau;
             double[] y1 = new double[length];
             double[] y2 = new double[length];
             for (int i = 0; i < length; i++)
             {
-                y1[i] = y[i];
-                y2[i] = y[i + tau];
+                y1[i] = yWork[i];
+                y2[i] = yWork[i + tau];
             }
 
-            double maxValue = Stats.max_(y);
-            double minValue = Stats.min_(y);
+            double maxValue = Stats.max_(yWork);
+            double minValue = Stats.min_(yWork);
             double binStep = (maxValue - minValue + 0.2) / numBins;
             double[] binEdges = new double[numBins + 1];
             for (int i = 0; i < numBins + 1; i++)

--- a/Catch22SharpTest/CO_FirstMin_ac.cs
+++ b/Catch22SharpTest/CO_FirstMin_ac.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class CO_FirstMin_ac_Tests
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.CO_FirstMin_ac(TestData.Test1);
+            var expected = TestData.Test1Output["CO_FirstMin_ac"];
+            Assert.AreEqual((int)expected, actual);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.CO_FirstMin_ac(TestData.Test2);
+            var expected = TestData.Test2Output["CO_FirstMin_ac"];
+            Assert.AreEqual((int)expected, actual);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.CO_FirstMin_ac(TestData.TestShort);
+            var expected = TestData.TestShortOutput["CO_FirstMin_ac"];
+            Assert.AreEqual((int)expected, actual);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.CO_FirstMin_ac(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["CO_FirstMin_ac"];
+            Assert.AreEqual((int)expected, actual);
+        }
+    }
+}

--- a/Catch22SharpTest/CO_HistogramAMI_even_2_5.cs
+++ b/Catch22SharpTest/CO_HistogramAMI_even_2_5.cs
@@ -1,0 +1,42 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class CO_HistogramAMI_even_2_5_Tests
+    {
+        private const double Tolerance = 1.0E-6;
+
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.CO_HistogramAMI_even_2_5(TestData.Test1);
+            var expected = TestData.Test1Output["CO_HistogramAMI_even_2_5"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.CO_HistogramAMI_even_2_5(TestData.Test2);
+            var expected = TestData.Test2Output["CO_HistogramAMI_even_2_5"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.CO_HistogramAMI_even_2_5(TestData.TestShort);
+            var expected = TestData.TestShortOutput["CO_HistogramAMI_even_2_5"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.CO_HistogramAMI_even_2_5(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["CO_HistogramAMI_even_2_5"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+    }
+}

--- a/Catch22SharpTest/CO_f1ecac.cs
+++ b/Catch22SharpTest/CO_f1ecac.cs
@@ -1,0 +1,42 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class CO_f1ecac_Tests
+    {
+        private const double Tolerance = 1.0E-6;
+
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.CO_f1ecac(TestData.Test1);
+            var expected = TestData.Test1Output["CO_f1ecac"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.CO_f1ecac(TestData.Test2);
+            var expected = TestData.Test2Output["CO_f1ecac"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.CO_f1ecac(TestData.TestShort);
+            var expected = TestData.TestShortOutput["CO_f1ecac"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.CO_f1ecac(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["CO_f1ecac"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+    }
+}

--- a/Catch22SharpTest/CO_trev_1_num.cs
+++ b/Catch22SharpTest/CO_trev_1_num.cs
@@ -1,0 +1,42 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class CO_trev_1_num_Tests
+    {
+        private const double Tolerance = 1.0E-6;
+
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.CO_trev_1_num(TestData.Test1);
+            var expected = TestData.Test1Output["CO_trev_1_num"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.CO_trev_1_num(TestData.Test2);
+            var expected = TestData.Test2Output["CO_trev_1_num"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.CO_trev_1_num(TestData.TestShort);
+            var expected = TestData.TestShortOutput["CO_trev_1_num"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.CO_trev_1_num(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["CO_trev_1_num"];
+            Assert.AreEqual(expected, actual, Tolerance);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MSTest coverage for CO_f1ecac, CO_FirstMin_ac, CO_HistogramAMI_even_2_5, and CO_trev_1_num
- normalize inputs inside CO_trev_1_num and CO_HistogramAMI_even_2_5 to align with reference outputs

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db1f60a0a88326a364d32a3781512c