### PR TITLE
Add tests for IN_AutoMutualInfoStats

### DIFF
--- a/Catch22Sharp/IN_AutoMutualInfoStats.cs
+++ b/Catch22Sharp/IN_AutoMutualInfoStats.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace Catch22Sharp
+{
+    public static partial class Catch22
+    {
+        public static double IN_AutoMutualInfoStats_40_gaussian_fmmi(Span<double> y)
+        {
+            for (int i = 0; i < y.Length; i++)
+            {
+                if (double.IsNaN(y[i]))
+                {
+                    return double.NaN;
+                }
+            }
+
+            int tau = 40;
+            int halfLengthCeil = (int)Math.Ceiling(y.Length / 2.0);
+            if (tau > halfLengthCeil)
+            {
+                tau = halfLengthCeil;
+            }
+
+            if (tau <= 0)
+            {
+                return 0.0;
+            }
+
+            double[] ami = new double[tau];
+            for (int i = 0; i < tau; i++)
+            {
+                double ac = Stats.autocorr_lag(y, i + 1);
+                double term = 1.0 - ac * ac;
+                if (term <= 0.0)
+                {
+                    ami[i] = double.PositiveInfinity;
+                }
+                else
+                {
+                    ami[i] = -0.5 * Math.Log(term);
+                }
+            }
+
+            double fmmi = tau;
+            for (int i = 1; i < tau - 1; i++)
+            {
+                if (ami[i] < ami[i - 1] && ami[i] < ami[i + 1])
+                {
+                    fmmi = i;
+                    break;
+                }
+            }
+
+            return fmmi;
+        }
+    }
+}

--- a/Catch22SharpTest/IN_AutoMutualInfoStats_40_gaussian_fmmi.cs
+++ b/Catch22SharpTest/IN_AutoMutualInfoStats_40_gaussian_fmmi.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class IN_AutoMutualInfoStats_40_gaussian_fmmi
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.IN_AutoMutualInfoStats_40_gaussian_fmmi(TestData.Test1);
+            var expected = TestData.Test1Output["IN_AutoMutualInfoStats_40_gaussian_fmmi"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.IN_AutoMutualInfoStats_40_gaussian_fmmi(TestData.Test2);
+            var expected = TestData.Test2Output["IN_AutoMutualInfoStats_40_gaussian_fmmi"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.IN_AutoMutualInfoStats_40_gaussian_fmmi(TestData.TestShort);
+            var expected = TestData.TestShortOutput["IN_AutoMutualInfoStats_40_gaussian_fmmi"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.IN_AutoMutualInfoStats_40_gaussian_fmmi(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["IN_AutoMutualInfoStats_40_gaussian_fmmi"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MSTest coverage for IN_AutoMutualInfoStats_40_gaussian_fmmi using existing datasets

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db2ce4f3f88326bfbbf4e8fc8a3d22