### PR TITLE
Normalize MD hrv classic pnn40 calculation and add tests

### DIFF
--- a/Catch22Sharp/MD_hrv.cs
+++ b/Catch22Sharp/MD_hrv.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Catch22Sharp
+{
+    public static partial class Catch22
+    {
+        public static double MD_hrv_classic_pnn40(Span<double> y, int size)
+        {
+            Span<double> ySpan = size < y.Length ? y.Slice(0, size) : y;
+
+            for (int i = 0; i < ySpan.Length; i++)
+            {
+                if (double.IsNaN(ySpan[i]))
+                {
+                    return double.NaN;
+                }
+            }
+
+            if (ySpan.Length <= 1)
+            {
+                return double.NaN;
+            }
+
+            const int pNNx = 40;
+
+            double[] yWork = new double[ySpan.Length];
+            Stats.zscore_norm2(ySpan, yWork.AsSpan());
+
+            double[] Dy = new double[yWork.Length - 1];
+            Stats.diff(yWork.AsSpan(), Dy.AsSpan());
+
+            double pnn40 = 0.0;
+            for (int i = 0; i < Dy.Length; i++)
+            {
+                if (Math.Abs(Dy[i]) * 1000.0 > pNNx)
+                {
+                    pnn40 += 1.0;
+                }
+            }
+
+            return pnn40 / (ySpan.Length - 1);
+        }
+    }
+}

--- a/Catch22SharpTest/MD_hrv_classic_pnn40.cs
+++ b/Catch22SharpTest/MD_hrv_classic_pnn40.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class MD_hrv_classic_pnn40
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.Test1, TestData.Test1.Length);
+            var expected = TestData.Test1Output["MD_hrv_classic_pnn40"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.Test2, TestData.Test2.Length);
+            var expected = TestData.Test2Output["MD_hrv_classic_pnn40"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestShort, TestData.TestShort.Length);
+            var expected = TestData.TestShortOutput["MD_hrv_classic_pnn40"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestSinusoid, TestData.TestSinusoid.Length);
+            var expected = TestData.TestSinusoidOutput["MD_hrv_classic_pnn40"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- z-score the input inside MD_hrv_classic_pnn40 before measuring RR-interval threshold exceedances
- add unit tests for MD_hrv_classic_pnn40 using the shared test datasets

## Testing
- dotnet test Catch22Sharp.sln

------
https://chatgpt.com/codex/tasks/task_e_68db30925300832695b9dad59a0be1ef