### PR TITLE
Normalize test data and align features with C implementation

### DIFF
--- a/Catch22Sharp/CO_AutoCorr.cs
+++ b/Catch22Sharp/CO_AutoCorr.cs
@@ -183,27 +183,23 @@ namespace Catch22Sharp
                 }
             }
 
-            double[] yZscored = new double[y.Length];
-            Stats.zscore_norm2(y, yZscored);
-            Span<double> yWork = yZscored;
-
-            int tau = co_firstzero(yWork, yWork.Length);
+            int tau = co_firstzero(y, y.Length);
             if (tau > y.Length / 10)
             {
                 tau = (int)Math.Floor(y.Length / 10.0);
             }
 
-            if (tau <= 0 || yWork.Length - tau - 1 <= 0)
+            if (tau <= 0 || y.Length - tau - 1 <= 0)
             {
                 return 0.0;
             }
 
-            int validLength = yWork.Length - tau - 1;
-            double[] d = new double[yWork.Length - tau];
+            int validLength = y.Length - tau - 1;
+            double[] d = new double[y.Length - tau];
             for (int i = 0; i < validLength; i++)
             {
-                double diff1 = yWork[i + 1] - yWork[i];
-                double diff2 = yWork[i + tau] - yWork[i + tau + 1];
+                double diff1 = y[i + 1] - y[i];
+                double diff2 = y[i + tau] - y[i + tau + 1];
                 d[i] = Math.Sqrt(diff1 * diff1 + diff2 * diff2);
                 if (double.IsNaN(d[i]))
                 {
@@ -283,17 +279,13 @@ namespace Catch22Sharp
                 return 0.0;
             }
 
-            double[] yZscored = new double[y.Length];
-            Stats.zscore_norm2(y, yZscored);
-            Span<double> yWork = yZscored;
-
-            double[] diffTemp = new double[yWork.Length - tau];
-            for (int i = 0; i < yWork.Length - tau; i++)
+            double[] diffTemp = new double[y.Length - tau];
+            for (int i = 0; i < y.Length - tau; i++)
             {
-                diffTemp[i] = Math.Pow(yWork[i + 1] - yWork[i], 3);
+                diffTemp[i] = Math.Pow(y[i + 1] - y[i], 3);
             }
 
-            return Stats.mean(diffTemp);
+            return Stats.mean(diffTemp.AsSpan());
         }
 
         public static double CO_HistogramAMI_even_2_5(Span<double> y)
@@ -313,21 +305,17 @@ namespace Catch22Sharp
                 return 0.0;
             }
 
-            double[] yZscored = new double[y.Length];
-            Stats.zscore_norm2(y, yZscored);
-            Span<double> yWork = yZscored;
-
-            int length = yWork.Length - tau;
+            int length = y.Length - tau;
             double[] y1 = new double[length];
             double[] y2 = new double[length];
             for (int i = 0; i < length; i++)
             {
-                y1[i] = yWork[i];
-                y2[i] = yWork[i + tau];
+                y1[i] = y[i];
+                y2[i] = y[i + tau];
             }
 
-            double maxValue = Stats.max_(yWork);
-            double minValue = Stats.min_(yWork);
+            double maxValue = Stats.max_(y);
+            double minValue = Stats.min_(y);
             double binStep = (maxValue - minValue + 0.2) / numBins;
             double[] binEdges = new double[numBins + 1];
             for (int i = 0; i < numBins + 1; i++)

--- a/Catch22Sharp/DN_HistogramMode_10.cs
+++ b/Catch22Sharp/DN_HistogramMode_10.cs
@@ -16,31 +16,16 @@ namespace Catch22Sharp
 
             const int nBins = 10;
 
-            double minVal = Stats.min_(y);
-            double maxVal = Stats.max_(y);
-            if (maxVal == minVal)
-            {
-                return minVal;
-            }
-
-            double[] yZscored = new double[y.Length];
-            Stats.zscore_norm2(y, yZscored.AsSpan());
-            Span<double> yWork = yZscored;
-
             int[] histCounts = new int[nBins];
             double[] binEdges = new double[nBins + 1];
-            HistCounts.histcounts_preallocated(yWork, nBins, histCounts.AsSpan(), binEdges.AsSpan());
-
-            double binStep = nBins > 0 ? binEdges[1] - binEdges[0] : 0.0;
-            double[] binCenters = new double[nBins];
-            HelperFunctions.linspace(binEdges[0] + binStep / 2.0, binEdges[nBins] - binStep / 2.0, nBins, binCenters.AsSpan());
+            HistCounts.histcounts_preallocated(y, nBins, histCounts.AsSpan(), binEdges.AsSpan());
 
             double maxCount = 0;
             int numMaxs = 1;
             double outputValue = 0;
             for (int i = 0; i < nBins; i++)
             {
-                double binMean = binCenters[i];
+                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
                 if (histCounts[i] > maxCount)
                 {
                     maxCount = histCounts[i];

--- a/Catch22Sharp/DN_HistogramMode_5.cs
+++ b/Catch22Sharp/DN_HistogramMode_5.cs
@@ -16,31 +16,16 @@ namespace Catch22Sharp
 
             const int nBins = 5;
 
-            double minVal = Stats.min_(y);
-            double maxVal = Stats.max_(y);
-            if (maxVal == minVal)
-            {
-                return minVal;
-            }
-
-            double[] yZscored = new double[y.Length];
-            Stats.zscore_norm2(y, yZscored.AsSpan());
-            Span<double> yWork = yZscored;
-
             int[] histCounts = new int[nBins];
             double[] binEdges = new double[nBins + 1];
-            HistCounts.histcounts_preallocated(yWork, nBins, histCounts.AsSpan(), binEdges.AsSpan());
-
-            double binStep = nBins > 0 ? binEdges[1] - binEdges[0] : 0.0;
-            double[] binCenters = new double[nBins];
-            HelperFunctions.linspace(binEdges[0] + binStep / 2.0, binEdges[nBins] - binStep / 2.0, nBins, binCenters.AsSpan());
+            HistCounts.histcounts_preallocated(y, nBins, histCounts.AsSpan(), binEdges.AsSpan());
 
             double maxCount = 0;
             int numMaxs = 1;
             double outputValue = 0;
             for (int i = 0; i < nBins; i++)
             {
-                double binMean = binCenters[i];
+                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
                 if (histCounts[i] > maxCount)
                 {
                     maxCount = histCounts[i];

--- a/Catch22Sharp/DN_OutlierInclude.cs
+++ b/Catch22Sharp/DN_OutlierInclude.cs
@@ -36,21 +36,16 @@ namespace Catch22Sharp
             }
 
             double[] yWork = new double[y.Length];
-            Stats.zscore_norm2(y, yWork.AsSpan());
 
             int tot = 0;
-            for (int i = 0; i < yWork.Length; i++)
+            for (int i = 0; i < y.Length; i++)
             {
-                yWork[i] = sign * yWork[i];
-                if (yWork[i] >= 0)
+                double value = sign * y[i];
+                yWork[i] = value;
+                if (value >= 0)
                 {
                     tot += 1;
                 }
-            }
-
-            if (tot == 0)
-            {
-                return 0.0;
             }
 
             double maxVal = Stats.max_(yWork.AsSpan());

--- a/Catch22Sharp/FC_LocalSimple.cs
+++ b/Catch22Sharp/FC_LocalSimple.cs
@@ -88,21 +88,17 @@ namespace Catch22Sharp
                 return 0.0;
             }
 
-            double[] yZscored = new double[ySpan.Length];
-            Stats.zscore_norm2(ySpan, yZscored.AsSpan());
-            Span<double> yWork = yZscored.AsSpan();
-
             double[] res = new double[residualLength];
             for (int i = 0; i < residualLength; i++)
             {
                 double yest = 0.0;
                 for (int j = 0; j < train_length; j++)
                 {
-                    yest += yWork[i + j];
+                    yest += ySpan[i + j];
                 }
 
                 yest /= train_length;
-                res[i] = yWork[i + train_length] - yest;
+                res[i] = ySpan[i + train_length] - yest;
             }
 
             double output = Stats.stddev(res.AsSpan());

--- a/Catch22Sharp/MD_hrv.cs
+++ b/Catch22Sharp/MD_hrv.cs
@@ -23,11 +23,8 @@ namespace Catch22Sharp
 
             const int pNNx = 40;
 
-            double[] yWork = new double[ySpan.Length];
-            Stats.zscore_norm2(ySpan, yWork.AsSpan());
-
-            double[] Dy = new double[yWork.Length - 1];
-            Stats.diff(yWork.AsSpan(), Dy.AsSpan());
+            double[] Dy = new double[ySpan.Length - 1];
+            Stats.diff(ySpan, Dy.AsSpan());
 
             double pnn40 = 0.0;
             for (int i = 0; i < Dy.Length; i++)

--- a/Catch22SharpTest/TestData.cs
+++ b/Catch22SharpTest/TestData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Catch22Sharp;
 
 namespace Catch22SharpTest
 {
@@ -69,12 +70,14 @@ namespace Catch22SharpTest
 
         private static double[] GetData(string path)
         {
-            return File.ReadLines(path).Select(double.Parse).ToArray();
+            var data = File.ReadLines(path).Select(double.Parse).ToArray();
+            return Normalize(data);
         }
 
         private static double[] GetData2(string path)
         {
-            return File.ReadAllText(path).Split(' ').Select(double.Parse).ToArray();
+            var data = File.ReadAllText(path).Split(' ').Select(double.Parse).ToArray();
+            return Normalize(data);
         }
 
         private static Dictionary<string, double> GetExpectedValues(string path)
@@ -95,6 +98,17 @@ namespace Catch22SharpTest
             }
 
             return dic;
+        }
+
+        private static double[] Normalize(double[] data)
+        {
+            if (data.Length <= 1)
+            {
+                return data;
+            }
+
+            Stats.zscore_norm(data.AsSpan());
+            return data;
         }
     }
 }


### PR DESCRIPTION
## Summary
- normalize test fixture inputs so they match the C driver's preprocessing
- remove redundant per-feature z-scoring and mirror the C implementations for the affected metrics

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db36cf26248326bd2928d12b860e2b