### PR TITLE
Align C# port with C reference implementation

### DIFF
--- a/Catch22Sharp/DN_HistogramMode_10.cs
+++ b/Catch22Sharp/DN_HistogramMode_10.cs
@@ -6,6 +6,7 @@ namespace Catch22Sharp
     {
         public static double DN_HistogramMode_10(Span<double> y)
         {
+            // NaN check
             for (int i = 0; i < y.Length; i++)
             {
                 if (double.IsNaN(y[i]))
@@ -16,30 +17,30 @@ namespace Catch22Sharp
 
             const int nBins = 10;
 
-            int[] histCounts = new int[nBins];
-            double[] binEdges = new double[nBins + 1];
-            HistCounts.histcounts_preallocated(y, nBins, histCounts.AsSpan(), binEdges.AsSpan());
+            HistCounts.histcounts(y, nBins, out int[] histCounts, out double[] binEdges);
 
             double maxCount = 0;
             int numMaxs = 1;
-            double outputValue = 0;
+            double @out = 0;
             for (int i = 0; i < nBins; i++)
             {
-                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
+                // printf("binInd=%i, binCount=%i, binEdge=%1.3f \\n", i, histCounts[i], binEdges[i]);
+
                 if (histCounts[i] > maxCount)
                 {
                     maxCount = histCounts[i];
                     numMaxs = 1;
-                    outputValue = binMean;
+                    @out = (binEdges[i] + binEdges[i + 1]) * 0.5;
                 }
                 else if (histCounts[i] == maxCount)
                 {
                     numMaxs += 1;
-                    outputValue += binMean;
+                    @out += (binEdges[i] + binEdges[i + 1]) * 0.5;
                 }
             }
+            @out = @out / numMaxs;
 
-            return outputValue / numMaxs;
+            return @out;
         }
     }
 }

--- a/Catch22Sharp/DN_HistogramMode_5.cs
+++ b/Catch22Sharp/DN_HistogramMode_5.cs
@@ -6,6 +6,7 @@ namespace Catch22Sharp
     {
         public static double DN_HistogramMode_5(Span<double> y)
         {
+            // NaN check
             for (int i = 0; i < y.Length; i++)
             {
                 if (double.IsNaN(y[i]))
@@ -16,30 +17,39 @@ namespace Catch22Sharp
 
             const int nBins = 5;
 
-            int[] histCounts = new int[nBins];
-            double[] binEdges = new double[nBins + 1];
-            HistCounts.histcounts_preallocated(y, nBins, histCounts.AsSpan(), binEdges.AsSpan());
+            HistCounts.histcounts(y, nBins, out int[] histCounts, out double[] binEdges);
+
+            /*
+            for(int i = 0; i < nBins; i++){
+                printf("histCounts[%i] = %i\\n", i, histCounts[i]);
+            }
+            for(int i = 0; i < nBins+1; i++){
+                printf("binEdges[%i] = %1.3f\\n", i, binEdges[i]);
+            }
+             */
 
             double maxCount = 0;
             int numMaxs = 1;
-            double outputValue = 0;
+            double @out = 0;
             for (int i = 0; i < nBins; i++)
             {
-                double binMean = (binEdges[i] + binEdges[i + 1]) * 0.5;
+                // printf("binInd=%i, binCount=%i, binEdge=%1.3f \\n", i, histCounts[i], binEdges[i]);
+
                 if (histCounts[i] > maxCount)
                 {
                     maxCount = histCounts[i];
                     numMaxs = 1;
-                    outputValue = binMean;
+                    @out = (binEdges[i] + binEdges[i + 1]) * 0.5;
                 }
                 else if (histCounts[i] == maxCount)
                 {
                     numMaxs += 1;
-                    outputValue += binMean;
+                    @out += (binEdges[i] + binEdges[i + 1]) * 0.5;
                 }
             }
+            @out = @out / numMaxs;
 
-            return outputValue / numMaxs;
+            return @out;
         }
     }
 }

--- a/Catch22Sharp/IN_AutoMutualInfoStats.cs
+++ b/Catch22Sharp/IN_AutoMutualInfoStats.cs
@@ -6,6 +6,7 @@ namespace Catch22Sharp
     {
         public static double IN_AutoMutualInfoStats_40_gaussian_fmmi(Span<double> y)
         {
+            // NaN check
             for (int i = 0; i < y.Length; i++)
             {
                 if (double.IsNaN(y[i]))
@@ -14,39 +15,32 @@ namespace Catch22Sharp
                 }
             }
 
+            // maximum time delay
             int tau = 40;
-            int halfLengthCeil = (int)Math.Ceiling(y.Length / 2.0);
-            if (tau > halfLengthCeil)
+
+            // don't go above half the signal length
+            if (tau > Math.Ceiling(y.Length / 2.0))
             {
-                tau = halfLengthCeil;
+                tau = (int)Math.Ceiling(y.Length / 2.0);
             }
 
-            if (tau <= 0)
-            {
-                return 0.0;
-            }
-
-            double[] ami = new double[tau];
+            // compute autocorrelations and compute automutual information
+            double[] ami = new double[y.Length];
             for (int i = 0; i < tau; i++)
             {
                 double ac = Stats.autocorr_lag(y, i + 1);
-                double term = 1.0 - ac * ac;
-                if (term <= 0.0)
-                {
-                    ami[i] = double.PositiveInfinity;
-                }
-                else
-                {
-                    ami[i] = -0.5 * Math.Log(term);
-                }
+                ami[i] = -0.5 * Math.Log(1 - ac * ac);
+                // printf("ami[%i]=%1.7f\\n", i, ami[i]);
             }
 
+            // find first minimum of automutual information
             double fmmi = tau;
             for (int i = 1; i < tau - 1; i++)
             {
-                if (ami[i] < ami[i - 1] && ami[i] < ami[i + 1])
+                if (ami[i] < ami[i - 1] & ami[i] < ami[i + 1])
                 {
                     fmmi = i;
+                    // printf("found minimum at %i\\n", i);
                     break;
                 }
             }

--- a/Catch22Sharp/MD_hrv.cs
+++ b/Catch22Sharp/MD_hrv.cs
@@ -6,9 +6,10 @@ namespace Catch22Sharp
     {
         public static double MD_hrv_classic_pnn40(Span<double> y, int size)
         {
-            Span<double> ySpan = size < y.Length ? y.Slice(0, size) : y;
+            Span<double> ySpan = y.Slice(0, size);
 
-            for (int i = 0; i < ySpan.Length; i++)
+            // NaN check
+            for (int i = 0; i < size; i++)
             {
                 if (double.IsNaN(ySpan[i]))
                 {
@@ -16,26 +17,22 @@ namespace Catch22Sharp
                 }
             }
 
-            if (ySpan.Length <= 1)
-            {
-                return double.NaN;
-            }
-
             const int pNNx = 40;
 
-            double[] Dy = new double[ySpan.Length - 1];
+            // compute diff
+            double[] Dy = new double[size - 1];
             Stats.diff(ySpan, Dy.AsSpan());
 
-            double pnn40 = 0.0;
-            for (int i = 0; i < Dy.Length; i++)
+            double pnn40 = 0;
+            for (int i = 0; i < size - 1; i++)
             {
-                if (Math.Abs(Dy[i]) * 1000.0 > pNNx)
+                if (Math.Abs(Dy[i]) * 1000 > pNNx)
                 {
-                    pnn40 += 1.0;
+                    pnn40 += 1;
                 }
             }
 
-            return pnn40 / (ySpan.Length - 1);
+            return pnn40 / (size - 1);
         }
     }
 }

--- a/Catch22Sharp/fft.cs
+++ b/Catch22Sharp/fft.cs
@@ -7,28 +7,30 @@ namespace Catch22Sharp
     {
         public static void twiddles(Span<Complex> a)
         {
-            double pi = Math.PI;
             int size = a.Length;
+            double PI = 3.14159265359;
+
             for (int i = 0; i < size; i++)
             {
-                double angle = -pi * i / size;
-                a[i] = Complex.Exp(new Complex(0.0, angle));
+                Complex tmp = Complex.Zero - PI * i / size * Complex.ImaginaryOne;
+                a[i] = Complex.Exp(tmp);
+                //a[i] = cexp(-I * M_PI * i / size);
             }
         }
 
-        private static void RecursiveFft(Complex[] a, Complex[] outBuf, int size, int step, Complex[] tw, int aOffset, int outOffset)
+        private static void _fft(Complex[] a, Complex[] @out, int size, int step, Complex[] tw, int aOffset, int outOffset)
         {
             if (step < size)
             {
-                RecursiveFft(outBuf, a, size, step * 2, tw, outOffset, aOffset);
-                RecursiveFft(outBuf, a, size, step * 2, tw, outOffset + step, aOffset + step);
+                _fft(@out, a, size, step * 2, tw, outOffset, aOffset);
+                _fft(@out, a, size, step * 2, tw, outOffset + step, aOffset + step);
 
                 for (int i = 0; i < size; i += 2 * step)
                 {
-                    int outIndex = outOffset + i;
-                    Complex t = tw[i] * outBuf[outIndex + step];
-                    a[aOffset + i / 2] = outBuf[outIndex] + t;
-                    a[aOffset + (i + size) / 2] = outBuf[outIndex] - t;
+                    int idx = outOffset + i;
+                    Complex t = tw[i] * @out[idx + step];
+                    a[aOffset + i / 2] = @out[idx] + t;
+                    a[aOffset + (i + size) / 2] = @out[idx] - t;
                 }
             }
         }
@@ -40,7 +42,7 @@ namespace Catch22Sharp
             Complex[] outArray = new Complex[size];
             Array.Copy(aArray, outArray, size);
             Complex[] twArray = tw.ToArray();
-            RecursiveFft(aArray, outArray, size, 1, twArray, 0, 0);
+            _fft(aArray, outArray, size, 1, twArray, 0, 0);
             for (int i = 0; i < size; i++)
             {
                 a[i] = aArray[i];

--- a/Catch22Sharp/stats.cs
+++ b/Catch22Sharp/stats.cs
@@ -6,8 +6,9 @@ namespace Catch22Sharp
     {
         public static double min_(Span<double> a)
         {
+            int size = a.Length;
             double m = a[0];
-            for (int i = 1; i < a.Length; i++)
+            for (int i = 1; i < size; i++)
             {
                 if (a[i] < m)
                 {
@@ -19,8 +20,9 @@ namespace Catch22Sharp
 
         public static double max_(Span<double> a)
         {
+            int size = a.Length;
             double m = a[0];
-            for (int i = 1; i < a.Length; i++)
+            for (int i = 1; i < size; i++)
             {
                 if (a[i] > m)
                 {
@@ -32,19 +34,21 @@ namespace Catch22Sharp
 
         public static double mean(Span<double> a)
         {
+            int size = a.Length;
             double m = 0.0;
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < size; i++)
             {
                 m += a[i];
             }
-            m /= a.Length;
+            m /= size;
             return m;
         }
 
         public static double sum(Span<double> a)
         {
+            int size = a.Length;
             double m = 0.0;
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < size; i++)
             {
                 m += a[i];
             }
@@ -53,26 +57,31 @@ namespace Catch22Sharp
 
         public static void cumsum(Span<double> a, Span<double> b)
         {
+            int size = a.Length;
             b[0] = a[0];
-            for (int i = 1; i < a.Length; i++)
+            for (int i = 1; i < size; i++)
             {
                 b[i] = a[i] + b[i - 1];
+                //printf("b[%i]%1.3f = a[%i]%1.3f + b[%i-1]%1.3f\\n", i, b[i], i, a[i], i, a[i-1]);
             }
         }
 
         public static void icumsum(Span<int> a, Span<int> b)
         {
+            int size = a.Length;
             b[0] = a[0];
-            for (int i = 1; i < a.Length; i++)
+            for (int i = 1; i < size; i++)
             {
                 b[i] = a[i] + b[i - 1];
+                //printf("b[%i]%1.3f = a[%i]%1.3f + b[%i-1]%1.3f\\n", i, b[i], i, a[i], i, a[i-1]);
             }
         }
 
         public static double isum(Span<int> a)
         {
+            int size = a.Length;
             double m = 0.0;
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < size; i++)
             {
                 m += a[i];
             }
@@ -81,17 +90,18 @@ namespace Catch22Sharp
 
         public static double median(Span<double> a)
         {
+            int size = a.Length;
             double m;
-            double[] b = new double[a.Length];
+            double[] b = new double[size];
             a.CopyTo(b);
-            Array.Sort(b);
-            if (a.Length % 2 == 1)
+            HelperFunctions.sort(b.AsSpan());
+            if (size % 2 == 1)
             {
-                m = b[a.Length / 2];
+                m = b[size / 2];
             }
             else
             {
-                int m1 = a.Length / 2;
+                int m1 = size / 2;
                 int m2 = m1 - 1;
                 m = (b[m1] + b[m2]) / 2.0;
             }
@@ -100,69 +110,81 @@ namespace Catch22Sharp
 
         public static double stddev(Span<double> a)
         {
+            int size = a.Length;
             double m = mean(a);
             double sd = 0.0;
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < size; i++)
             {
                 sd += Math.Pow(a[i] - m, 2);
             }
-            sd = Math.Sqrt(sd / (a.Length - 1));
+            sd = Math.Sqrt(sd / (size - 1));
             return sd;
         }
 
         public static double cov(Span<double> x, Span<double> y)
         {
+            int size = x.Length;
             double covariance = 0;
             double meanX = mean(x);
             double meanY = mean(y);
-            for (int i = 0; i < x.Length; i++)
+            for (int i = 0; i < size; i++)
             {
+                // double xi =x[i];
+                // double yi =y[i];
                 covariance += (x[i] - meanX) * (y[i] - meanY);
             }
-            return covariance / (x.Length - 1);
+            return covariance / (size - 1);
         }
 
         public static double cov_mean(Span<double> x, Span<double> y)
         {
+            int size = x.Length;
             double covariance = 0;
-            for (int i = 0; i < x.Length; i++)
+            for (int i = 0; i < size; i++)
             {
+                // double xi =x[i];
+                // double yi =y[i];
                 covariance += x[i] * y[i];
             }
-            return covariance / x.Length;
+            return covariance / size;
         }
 
         public static double corr(Span<double> x, Span<double> y)
         {
+            int size = x.Length;
             double nom = 0;
             double denomX = 0;
             double denomY = 0;
             double meanX = mean(x);
             double meanY = mean(y);
-            for (int i = 0; i < x.Length; i++)
+            for (int i = 0; i < size; i++)
             {
                 nom += (x[i] - meanX) * (y[i] - meanY);
                 denomX += (x[i] - meanX) * (x[i] - meanX);
                 denomY += (y[i] - meanY) * (y[i] - meanY);
+                //printf("x[%i]=%1.3f, y[%i]=%1.3f, nom[%i]=%1.3f, denomX[%i]=%1.3f, denomY[%i]=%1.3f\\n", i, x[i], i, y[i], i, nom, i, denomX, i, denomY);
             }
             return nom / Math.Sqrt(denomX * denomY);
         }
 
         public static double autocorr_lag(Span<double> x, int lag)
         {
-            return corr(x.Slice(0, x.Length - lag), x.Slice(lag, x.Length - lag));
+            int size = x.Length;
+            return corr(x.Slice(0, size - lag), x.Slice(lag, size - lag));
         }
 
         public static double autocov_lag(Span<double> x, int lag)
         {
-            return cov_mean(x.Slice(0, x.Length - lag), x.Slice(lag, x.Length - lag));
+            int size = x.Length;
+            return cov_mean(x.Slice(0, size - lag), x.Slice(lag, size - lag));
         }
 
         public static void zscore_norm(Span<double> a)
         {
+            int size = a.Length;
             double m = mean(a);
             double sd = stddev(a);
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < size; i++)
             {
                 a[i] = (a[i] - m) / sd;
             }
@@ -170,9 +192,10 @@ namespace Catch22Sharp
 
         public static void zscore_norm2(Span<double> a, Span<double> b)
         {
+            int size = a.Length;
             double m = mean(a);
             double sd = stddev(a);
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < size; i++)
             {
                 b[i] = (a[i] - m) / sd;
             }
@@ -181,21 +204,22 @@ namespace Catch22Sharp
         public static double moment(Span<double> a, int start, int end, int r)
         {
             int win_size = end - start + 1;
-            Span<double> sub = a.Slice(start, win_size);
-            double m = mean(sub);
+            Span<double> window = a.Slice(start, win_size);
+            double m = mean(window);
             double mr = 0.0;
             for (int i = 0; i < win_size; i++)
             {
-                mr += Math.Pow(sub[i] - m, r);
+                mr += Math.Pow(window[i] - m, r);
             }
             mr /= win_size;
-            mr /= stddev(sub); //normalize
+            mr /= stddev(window); //normalize
             return mr;
         }
 
         public static void diff(Span<double> a, Span<double> b)
         {
-            for (int i = 1; i < a.Length; i++)
+            int size = a.Length;
+            for (int i = 1; i < size; i++)
             {
                 b[i - 1] = a[i] - a[i - 1];
             }
@@ -203,11 +227,12 @@ namespace Catch22Sharp
 
         public static int linreg(int n, Span<double> x, Span<double> y, out double m, out double b)
         {
-            double sumx = 0.0;
-            double sumx2 = 0.0;
-            double sumxy = 0.0;
-            double sumy = 0.0;
-            double sumy2 = 0.0;
+            double sumx = 0.0;                      /* sum of x     */
+            double sumx2 = 0.0;                     /* sum of x**2  */
+            double sumxy = 0.0;                     /* sum of x * y */
+            double sumy = 0.0;                      /* sum of y     */
+            double sumy2 = 0.0;                     /* sum of y**2  */
+
             for (int i = 0; i < n; i++)
             {
                 sumx += x[i];
@@ -216,27 +241,39 @@ namespace Catch22Sharp
                 sumy += y[i];
                 sumy2 += y[i] * y[i];
             }
-            double denom = (n * sumx2 - sumx * sumx);
+
+            double denom = n * sumx2 - sumx * sumx;
             if (denom == 0)
             {
+                // singular matrix. can't solve the problem.
                 m = 0;
                 b = 0;
                 return 1;
             }
+
             m = (n * sumxy - sumx * sumy) / denom;
             b = (sumy * sumx2 - sumx * sumxy) / denom;
+
+            /*if (r!=NULL) {
+                *r = (sumxy - sumx * sumy / n) /
+                sqrt((sumx2 - sumx * sumx/n) *
+                     (sumy2 - sumy * sumy/n));
+            }
+            */
+
             return 0;
         }
 
         public static double norm_(Span<double> a)
         {
-            double outVal = 0.0;
-            for (int i = 0; i < a.Length; i++)
+            int size = a.Length;
+            double @out = 0.0;
+            for (int i = 0; i < size; i++)
             {
-                outVal += a[i] * a[i];
+                @out += a[i] * a[i];
             }
-            outVal = Math.Sqrt(outVal);
-            return outVal;
+            @out = Math.Sqrt(@out);
+            return @out;
         }
     }
 }


### PR DESCRIPTION
## Summary
- mirror the C auto-correlation routines and helper logic in the C# port, restoring original variable names and comments
- translate outlier-include, histogram-mode, local statistics, mutual information, FFT, and HRV routines to the C structure with matching comments
- align helper utilities and histogram helpers with the C code so downstream calls share the same naming and flow

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db3a57d3f48326baf209a4686bf9e3