### PR TITLE
Refactor span usage to use ReadOnlySpan and remove size arguments

### DIFF
--- a/Catch22Sharp/CO_AutoCorr.cs
+++ b/Catch22Sharp/CO_AutoCorr.cs
@@ -17,15 +17,16 @@ namespace Catch22Sharp
             return n;
         }
 
-        private static void dot_multiply(Span<Complex> a, Span<Complex> b, int size)
+        private static void dot_multiply(Span<Complex> a, ReadOnlySpan<Complex> b)
         {
+            int size = Math.Min(a.Length, b.Length);
             for (int i = 0; i < size; i++)
             {
                 a[i] = a[i] * Complex.Conjugate(b[i]);
             }
         }
 
-        private static double[] co_autocorrs(Span<double> y)
+        private static double[] co_autocorrs(ReadOnlySpan<double> y)
         {
             int size = y.Length;
             double m;
@@ -46,7 +47,7 @@ namespace Catch22Sharp
 
             Fft.twiddles(tw.AsSpan());
             Fft.fft(F.AsSpan(), tw.AsSpan());
-            dot_multiply(F.AsSpan(), F.AsSpan(), nFFT);
+            dot_multiply(F.AsSpan(), F.AsSpan());
             Fft.fft(F.AsSpan(), tw.AsSpan());
             Complex divisor = F[0];
             for (int i = 0; i < nFFT; i++)
@@ -62,12 +63,13 @@ namespace Catch22Sharp
             return @out;
         }
 
-        private static int co_firstzero(Span<double> y, int maxtau)
+        private static int co_firstzero(ReadOnlySpan<double> y)
         {
             double[] autocorrs = co_autocorrs(y);
+            int limit = Math.Min(y.Length, autocorrs.Length);
 
             int zerocrossind = 0;
-            while (zerocrossind < maxtau && autocorrs[zerocrossind] > 0)
+            while (zerocrossind < limit && autocorrs[zerocrossind] > 0)
             {
                 zerocrossind += 1;
             }
@@ -75,7 +77,7 @@ namespace Catch22Sharp
             return zerocrossind;
         }
 
-        public static double[] CO_AutoCorr(Span<double> y, Span<int> tau)
+        public static double[] CO_AutoCorr(ReadOnlySpan<double> y, ReadOnlySpan<int> tau)
         {
             int tau_size = tau.Length;
             double[] autocorrs = co_autocorrs(y);
@@ -87,7 +89,7 @@ namespace Catch22Sharp
             return @out;
         }
 
-        public static double CO_f1ecac(Span<double> y)
+        public static double CO_f1ecac(ReadOnlySpan<double> y)
         {
             // NaN check
             for (int i = 0; i < y.Length; i++)
@@ -122,14 +124,14 @@ namespace Catch22Sharp
             return @out;
         }
 
-        public static double CO_Embed2_Basic_tau_incircle(Span<double> y, double radius, int tau)
+        public static double CO_Embed2_Basic_tau_incircle(ReadOnlySpan<double> y, double radius, int tau)
         {
             int size = y.Length;
             int tauIntern = 0;
 
             if (tau < 0)
             {
-                tauIntern = co_firstzero(y, size);
+                tauIntern = co_firstzero(y);
             }
             else
             {
@@ -148,7 +150,7 @@ namespace Catch22Sharp
             return insidecount / (size - tauIntern);
         }
 
-        public static double CO_Embed2_Dist_tau_d_expfit_meandiff(Span<double> y)
+        public static double CO_Embed2_Dist_tau_d_expfit_meandiff(ReadOnlySpan<double> y)
         {
             int size = y.Length;
 
@@ -161,7 +163,7 @@ namespace Catch22Sharp
                 }
             }
 
-            int tau = co_firstzero(y, size);
+            int tau = co_firstzero(y);
 
             //printf("co_firstzero ran\n");
 
@@ -254,7 +256,7 @@ namespace Catch22Sharp
             return @out;
         }
 
-        public static int CO_FirstMin_ac(Span<double> y)
+        public static int CO_FirstMin_ac(ReadOnlySpan<double> y)
         {
             // NaN check
             for (int i = 0; i < y.Length; i++)
@@ -280,7 +282,7 @@ namespace Catch22Sharp
             return minInd;
         }
 
-        public static double CO_trev_1_num(Span<double> y)
+        public static double CO_trev_1_num(ReadOnlySpan<double> y)
         {
             // NaN check
             for (int i = 0; i < y.Length; i++)
@@ -307,7 +309,7 @@ namespace Catch22Sharp
             return @out;
         }
 
-        public static double CO_HistogramAMI_even_2_5(Span<double> y)
+        public static double CO_HistogramAMI_even_2_5(ReadOnlySpan<double> y)
         {
             // NaN check
             for (int i = 0; i < y.Length; i++)

--- a/Catch22Sharp/DN_HistogramMode_10.cs
+++ b/Catch22Sharp/DN_HistogramMode_10.cs
@@ -4,7 +4,7 @@ namespace Catch22Sharp
 {
     public static partial class Catch22
     {
-        public static double DN_HistogramMode_10(Span<double> y)
+        public static double DN_HistogramMode_10(ReadOnlySpan<double> y)
         {
             // NaN check
             for (int i = 0; i < y.Length; i++)

--- a/Catch22Sharp/DN_HistogramMode_5.cs
+++ b/Catch22Sharp/DN_HistogramMode_5.cs
@@ -4,7 +4,7 @@ namespace Catch22Sharp
 {
     public static partial class Catch22
     {
-        public static double DN_HistogramMode_5(Span<double> y)
+        public static double DN_HistogramMode_5(ReadOnlySpan<double> y)
         {
             // NaN check
             for (int i = 0; i < y.Length; i++)

--- a/Catch22Sharp/DN_OutlierInclude.cs
+++ b/Catch22Sharp/DN_OutlierInclude.cs
@@ -4,7 +4,7 @@ namespace Catch22Sharp
 {
     public static partial class Catch22
     {
-        public static double DN_OutlierInclude_np_001_mdrmd(Span<double> y, int sign)
+        public static double DN_OutlierInclude_np_001_mdrmd(ReadOnlySpan<double> y, int sign)
         {
             int size = y.Length;
 
@@ -118,17 +118,17 @@ namespace Catch22Sharp
             return outputScalar;
         }
 
-        public static double DN_OutlierInclude_p_001_mdrmd(Span<double> y)
+        public static double DN_OutlierInclude_p_001_mdrmd(ReadOnlySpan<double> y)
         {
             return DN_OutlierInclude_np_001_mdrmd(y, 1);
         }
 
-        public static double DN_OutlierInclude_n_001_mdrmd(Span<double> y)
+        public static double DN_OutlierInclude_n_001_mdrmd(ReadOnlySpan<double> y)
         {
             return DN_OutlierInclude_np_001_mdrmd(y, -1);
         }
 
-        public static double DN_OutlierInclude_abs_001(Span<double> y)
+        public static double DN_OutlierInclude_abs_001(ReadOnlySpan<double> y)
         {
             int size = y.Length;
             double inc = 0.01;

--- a/Catch22Sharp/FC_LocalSimple.cs
+++ b/Catch22Sharp/FC_LocalSimple.cs
@@ -4,7 +4,7 @@ namespace Catch22Sharp
 {
     public static partial class Catch22
     {
-        private static void abs_diff(Span<double> a, Span<double> b)
+        private static void abs_diff(ReadOnlySpan<double> a, Span<double> b)
         {
             for (int i = 1; i < a.Length; i++)
             {
@@ -12,22 +12,22 @@ namespace Catch22Sharp
             }
         }
 
-        public static double fc_local_simple(Span<double> y, int size, int train_length)
+        public static double fc_local_simple(ReadOnlySpan<double> y, int train_length)
         {
-            Span<double> ySpan = y.Slice(0, size);
+            int size = y.Length;
             double[] y1 = new double[size - 1];
-            abs_diff(ySpan, y1.AsSpan());
+            abs_diff(y, y1.AsSpan());
             double m = Stats.mean(y1.AsSpan());
             return m;
         }
 
-        public static double FC_LocalSimple_mean_tauresrat(Span<double> y, int size, int train_length)
+        public static double FC_LocalSimple_mean_tauresrat(ReadOnlySpan<double> y, int train_length)
         {
-            Span<double> ySpan = y.Slice(0, size);
+            int size = y.Length;
             // NaN check
-            for (int i = 0; i < size; i++)
+            for (int i = 0; i < y.Length; i++)
             {
-                if (double.IsNaN(ySpan[i]))
+                if (double.IsNaN(y[i]))
                 {
                     return double.NaN;
                 }
@@ -40,27 +40,27 @@ namespace Catch22Sharp
                 double yest = 0.0;
                 for (int j = 0; j < train_length; j++)
                 {
-                    yest += ySpan[i + j];
+                    yest += y[i + j];
                 }
 
                 yest /= train_length;
-                res[i] = ySpan[i + train_length] - yest;
+                res[i] = y[i + train_length] - yest;
             }
 
-            double resAC1stZ = co_firstzero(res.AsSpan(), size - train_length);
-            double yAC1stZ = co_firstzero(ySpan, size);
+            double resAC1stZ = co_firstzero(res.AsSpan());
+            double yAC1stZ = co_firstzero(y);
             double output = resAC1stZ / yAC1stZ;
 
             return output;
         }
 
-        public static double FC_LocalSimple_mean_stderr(Span<double> y, int size, int train_length)
+        public static double FC_LocalSimple_mean_stderr(ReadOnlySpan<double> y, int train_length)
         {
-            Span<double> ySpan = y.Slice(0, size);
+            int size = y.Length;
             // NaN check
-            for (int i = 0; i < size; i++)
+            for (int i = 0; i < y.Length; i++)
             {
-                if (double.IsNaN(ySpan[i]))
+                if (double.IsNaN(y[i]))
                 {
                     return double.NaN;
                 }
@@ -72,11 +72,11 @@ namespace Catch22Sharp
                 double yest = 0.0;
                 for (int j = 0; j < train_length; j++)
                 {
-                    yest += ySpan[i + j];
+                    yest += y[i + j];
                 }
 
                 yest /= train_length;
-                res[i] = ySpan[i + train_length] - yest;
+                res[i] = y[i + train_length] - yest;
             }
 
             double output = Stats.stddev(res.AsSpan());
@@ -84,41 +84,41 @@ namespace Catch22Sharp
             return output;
         }
 
-        public static double FC_LocalSimple_mean3_stderr(Span<double> y, int size)
+        public static double FC_LocalSimple_mean3_stderr(ReadOnlySpan<double> y)
         {
-            return FC_LocalSimple_mean_stderr(y, size, 3);
+            return FC_LocalSimple_mean_stderr(y, 3);
         }
 
-        public static double FC_LocalSimple_mean1_tauresrat(Span<double> y, int size)
+        public static double FC_LocalSimple_mean1_tauresrat(ReadOnlySpan<double> y)
         {
-            return FC_LocalSimple_mean_tauresrat(y, size, 1);
+            return FC_LocalSimple_mean_tauresrat(y, 1);
         }
 
-        public static double FC_LocalSimple_mean_taures(Span<double> y, int size, int train_length)
+        public static double FC_LocalSimple_mean_taures(ReadOnlySpan<double> y, int train_length)
         {
-            Span<double> ySpan = y.Slice(0, size);
+            int size = y.Length;
             double[] res = new double[size - train_length];
             for (int i = 0; i < size - train_length; i++)
             {
                 double yest = 0.0;
                 for (int j = 0; j < train_length; j++)
                 {
-                    yest += ySpan[i + j];
+                    yest += y[i + j];
                 }
 
                 yest /= train_length;
-                res[i] = ySpan[i + train_length] - yest;
+                res[i] = y[i + train_length] - yest;
             }
 
-            int output = co_firstzero(res.AsSpan(), size - train_length);
+            int output = co_firstzero(res.AsSpan());
             return output;
         }
 
-        public static double FC_LocalSimple_lfit_taures(Span<double> y, int size)
+        public static double FC_LocalSimple_lfit_taures(ReadOnlySpan<double> y)
         {
-            Span<double> ySpan = y.Slice(0, size);
+            int size = y.Length;
             // set tau from first AC zero crossing
-            int train_length = co_firstzero(ySpan, size);
+            int train_length = co_firstzero(y);
 
             double[] xReg = new double[train_length];
             for (int i = 1; i < train_length + 1; i++)
@@ -130,15 +130,15 @@ namespace Catch22Sharp
 
             for (int i = 0; i < size - train_length; i++)
             {
-                Span<double> yReg = ySpan.Slice(i, train_length);
-                Stats.linreg(train_length, xReg.AsSpan(), yReg, out double m, out double b);
+                ReadOnlySpan<double> yReg = y.Slice(i, train_length);
+                Stats.linreg(xReg.AsSpan(), yReg, out double m, out double b);
 
                 // fprintf(stdout, "i=%i, m=%f, b=%f\\n", i, m, b);
 
-                res[i] = ySpan[i + train_length] - (m * (train_length + 1) + b);
+                res[i] = y[i + train_length] - (m * (train_length + 1) + b);
             }
 
-            int output = co_firstzero(res.AsSpan(), size - train_length);
+            int output = co_firstzero(res.AsSpan());
 
             return output;
         }

--- a/Catch22Sharp/IN_AutoMutualInfoStats.cs
+++ b/Catch22Sharp/IN_AutoMutualInfoStats.cs
@@ -4,7 +4,7 @@ namespace Catch22Sharp
 {
     public static partial class Catch22
     {
-        public static double IN_AutoMutualInfoStats_40_gaussian_fmmi(Span<double> y)
+        public static double IN_AutoMutualInfoStats_40_gaussian_fmmi(ReadOnlySpan<double> y)
         {
             // NaN check
             for (int i = 0; i < y.Length; i++)

--- a/Catch22Sharp/MD_hrv.cs
+++ b/Catch22Sharp/MD_hrv.cs
@@ -4,14 +4,14 @@ namespace Catch22Sharp
 {
     public static partial class Catch22
     {
-        public static double MD_hrv_classic_pnn40(Span<double> y, int size)
+        public static double MD_hrv_classic_pnn40(ReadOnlySpan<double> y)
         {
-            Span<double> ySpan = y.Slice(0, size);
+            int size = y.Length;
 
             // NaN check
             for (int i = 0; i < size; i++)
             {
-                if (double.IsNaN(ySpan[i]))
+                if (double.IsNaN(y[i]))
                 {
                     return double.NaN;
                 }
@@ -21,7 +21,7 @@ namespace Catch22Sharp
 
             // compute diff
             double[] Dy = new double[size - 1];
-            Stats.diff(ySpan, Dy.AsSpan());
+            Stats.diff(y, Dy.AsSpan());
 
             double pnn40 = 0;
             for (int i = 0; i < size - 1; i++)

--- a/Catch22Sharp/fft.cs
+++ b/Catch22Sharp/fft.cs
@@ -35,7 +35,7 @@ namespace Catch22Sharp
             }
         }
 
-        public static void fft(Span<Complex> a, Span<Complex> tw)
+        public static void fft(Span<Complex> a, ReadOnlySpan<Complex> tw)
         {
             int size = a.Length;
             Complex[] aArray = a.ToArray();

--- a/Catch22Sharp/helper_functions.cs
+++ b/Catch22Sharp/helper_functions.cs
@@ -33,7 +33,7 @@ namespace Catch22Sharp
             return;
         }
 
-        public static double quantile(Span<double> y, double quant)
+        public static double quantile(ReadOnlySpan<double> y, double quant)
         {
             int size = y.Length;
             double quant_idx;
@@ -65,7 +65,7 @@ namespace Catch22Sharp
             return value;
         }
 
-        public static void binarize(Span<double> a, Span<int> b, string how)
+        public static void binarize(ReadOnlySpan<double> a, Span<int> b, string how)
         {
             double m = 0.0;
             if (how == "mean")
@@ -84,7 +84,7 @@ namespace Catch22Sharp
             return;
         }
 
-        public static double f_entropy(Span<double> a)
+        public static double f_entropy(ReadOnlySpan<double> a)
         {
             double f = 0.0;
             for (int i = 0; i < a.Length; i++)
@@ -98,7 +98,7 @@ namespace Catch22Sharp
             return -1 * f;
         }
 
-        public static void subset(Span<int> a, int start, int end, Span<int> b)
+        public static void subset(ReadOnlySpan<int> a, int start, int end, Span<int> b)
         {
             int j = 0;
             for (int i = start; i < end; i++)

--- a/Catch22Sharp/histcounts.cs
+++ b/Catch22Sharp/histcounts.cs
@@ -4,7 +4,7 @@ namespace Catch22Sharp
 {
     public static class HistCounts
     {
-        public static int num_bins_auto(Span<double> y)
+        public static int num_bins_auto(ReadOnlySpan<double> y)
         {
             int size = y.Length;
 
@@ -19,7 +19,7 @@ namespace Catch22Sharp
             return (int)Math.Ceiling((maxVal - minVal) / (3.5 * Stats.stddev(y) / Math.Pow(size, 1 / 3.0)));
         }
 
-        public static int histcounts_preallocated(Span<double> y, int nBins, Span<int> binCounts, Span<double> binEdges)
+        public static int histcounts_preallocated(ReadOnlySpan<double> y, int nBins, Span<int> binCounts, Span<double> binEdges)
         {
             int size = y.Length;
 
@@ -80,7 +80,7 @@ namespace Catch22Sharp
             return 0;
         }
 
-        public static int histcounts(Span<double> y, int nBins, out int[] binCounts, out double[] binEdges)
+        public static int histcounts(ReadOnlySpan<double> y, int nBins, out int[] binCounts, out double[] binEdges)
         {
             int size = y.Length;
 
@@ -148,7 +148,7 @@ namespace Catch22Sharp
             return nBins;
         }
 
-        public static int[] histbinassign(Span<double> y, Span<double> binEdges)
+        public static int[] histbinassign(ReadOnlySpan<double> y, ReadOnlySpan<double> binEdges)
         {
             int size = y.Length;
 
@@ -173,7 +173,7 @@ namespace Catch22Sharp
             return binIdentity;
         }
 
-        public static int[] histcount_edges(Span<double> y, Span<double> binEdges)
+        public static int[] histcount_edges(ReadOnlySpan<double> y, ReadOnlySpan<double> binEdges)
         {
             int size = y.Length;
             int nEdges = binEdges.Length;

--- a/Catch22Sharp/stats.cs
+++ b/Catch22Sharp/stats.cs
@@ -4,7 +4,7 @@ namespace Catch22Sharp
 {
     public static class Stats
     {
-        public static double min_(Span<double> a)
+        public static double min_(ReadOnlySpan<double> a)
         {
             int size = a.Length;
             double m = a[0];
@@ -18,7 +18,7 @@ namespace Catch22Sharp
             return m;
         }
 
-        public static double max_(Span<double> a)
+        public static double max_(ReadOnlySpan<double> a)
         {
             int size = a.Length;
             double m = a[0];
@@ -32,7 +32,7 @@ namespace Catch22Sharp
             return m;
         }
 
-        public static double mean(Span<double> a)
+        public static double mean(ReadOnlySpan<double> a)
         {
             int size = a.Length;
             double m = 0.0;
@@ -44,7 +44,7 @@ namespace Catch22Sharp
             return m;
         }
 
-        public static double sum(Span<double> a)
+        public static double sum(ReadOnlySpan<double> a)
         {
             int size = a.Length;
             double m = 0.0;
@@ -55,7 +55,7 @@ namespace Catch22Sharp
             return m;
         }
 
-        public static void cumsum(Span<double> a, Span<double> b)
+        public static void cumsum(ReadOnlySpan<double> a, Span<double> b)
         {
             int size = a.Length;
             b[0] = a[0];
@@ -66,7 +66,7 @@ namespace Catch22Sharp
             }
         }
 
-        public static void icumsum(Span<int> a, Span<int> b)
+        public static void icumsum(ReadOnlySpan<int> a, Span<int> b)
         {
             int size = a.Length;
             b[0] = a[0];
@@ -77,7 +77,7 @@ namespace Catch22Sharp
             }
         }
 
-        public static double isum(Span<int> a)
+        public static double isum(ReadOnlySpan<int> a)
         {
             int size = a.Length;
             double m = 0.0;
@@ -88,7 +88,7 @@ namespace Catch22Sharp
             return m;
         }
 
-        public static double median(Span<double> a)
+        public static double median(ReadOnlySpan<double> a)
         {
             int size = a.Length;
             double m;
@@ -108,7 +108,7 @@ namespace Catch22Sharp
             return m;
         }
 
-        public static double stddev(Span<double> a)
+        public static double stddev(ReadOnlySpan<double> a)
         {
             int size = a.Length;
             double m = mean(a);
@@ -121,7 +121,7 @@ namespace Catch22Sharp
             return sd;
         }
 
-        public static double cov(Span<double> x, Span<double> y)
+        public static double cov(ReadOnlySpan<double> x, ReadOnlySpan<double> y)
         {
             int size = x.Length;
             double covariance = 0;
@@ -136,7 +136,7 @@ namespace Catch22Sharp
             return covariance / (size - 1);
         }
 
-        public static double cov_mean(Span<double> x, Span<double> y)
+        public static double cov_mean(ReadOnlySpan<double> x, ReadOnlySpan<double> y)
         {
             int size = x.Length;
             double covariance = 0;
@@ -149,7 +149,7 @@ namespace Catch22Sharp
             return covariance / size;
         }
 
-        public static double corr(Span<double> x, Span<double> y)
+        public static double corr(ReadOnlySpan<double> x, ReadOnlySpan<double> y)
         {
             int size = x.Length;
             double nom = 0;
@@ -167,13 +167,13 @@ namespace Catch22Sharp
             return nom / Math.Sqrt(denomX * denomY);
         }
 
-        public static double autocorr_lag(Span<double> x, int lag)
+        public static double autocorr_lag(ReadOnlySpan<double> x, int lag)
         {
             int size = x.Length;
             return corr(x.Slice(0, size - lag), x.Slice(lag, size - lag));
         }
 
-        public static double autocov_lag(Span<double> x, int lag)
+        public static double autocov_lag(ReadOnlySpan<double> x, int lag)
         {
             int size = x.Length;
             return cov_mean(x.Slice(0, size - lag), x.Slice(lag, size - lag));
@@ -190,7 +190,7 @@ namespace Catch22Sharp
             }
         }
 
-        public static void zscore_norm2(Span<double> a, Span<double> b)
+        public static void zscore_norm2(ReadOnlySpan<double> a, Span<double> b)
         {
             int size = a.Length;
             double m = mean(a);
@@ -201,10 +201,10 @@ namespace Catch22Sharp
             }
         }
 
-        public static double moment(Span<double> a, int start, int end, int r)
+        public static double moment(ReadOnlySpan<double> a, int start, int end, int r)
         {
             int win_size = end - start + 1;
-            Span<double> window = a.Slice(start, win_size);
+            ReadOnlySpan<double> window = a.Slice(start, win_size);
             double m = mean(window);
             double mr = 0.0;
             for (int i = 0; i < win_size; i++)
@@ -216,7 +216,7 @@ namespace Catch22Sharp
             return mr;
         }
 
-        public static void diff(Span<double> a, Span<double> b)
+        public static void diff(ReadOnlySpan<double> a, Span<double> b)
         {
             int size = a.Length;
             for (int i = 1; i < size; i++)
@@ -225,13 +225,20 @@ namespace Catch22Sharp
             }
         }
 
-        public static int linreg(int n, Span<double> x, Span<double> y, out double m, out double b)
+        public static int linreg(ReadOnlySpan<double> x, ReadOnlySpan<double> y, out double m, out double b)
         {
             double sumx = 0.0;                      /* sum of x     */
             double sumx2 = 0.0;                     /* sum of x**2  */
             double sumxy = 0.0;                     /* sum of x * y */
             double sumy = 0.0;                      /* sum of y     */
             double sumy2 = 0.0;                     /* sum of y**2  */
+
+            if (x.Length != y.Length)
+            {
+                throw new ArgumentException("Span lengths must match.");
+            }
+
+            int n = x.Length;
 
             for (int i = 0; i < n; i++)
             {
@@ -264,7 +271,7 @@ namespace Catch22Sharp
             return 0;
         }
 
-        public static double norm_(Span<double> a)
+        public static double norm_(ReadOnlySpan<double> a)
         {
             int size = a.Length;
             double @out = 0.0;

--- a/Catch22SharpTest/FC_LocalSimple_mean1_tauresrat.cs
+++ b/Catch22SharpTest/FC_LocalSimple_mean1_tauresrat.cs
@@ -8,7 +8,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void Test1()
         {
-            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.Test1, TestData.Test1.Length);
+            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.Test1);
             var expected = TestData.Test1Output["FC_LocalSimple_mean1_tauresrat"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -16,7 +16,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void Test2()
         {
-            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.Test2, TestData.Test2.Length);
+            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.Test2);
             var expected = TestData.Test2Output["FC_LocalSimple_mean1_tauresrat"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -24,7 +24,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void TestShort()
         {
-            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.TestShort, TestData.TestShort.Length);
+            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.TestShort);
             var expected = TestData.TestShortOutput["FC_LocalSimple_mean1_tauresrat"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -32,7 +32,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void TestSinusoid()
         {
-            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.TestSinusoid, TestData.TestSinusoid.Length);
+            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.TestSinusoid);
             var expected = TestData.TestSinusoidOutput["FC_LocalSimple_mean1_tauresrat"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }

--- a/Catch22SharpTest/FC_LocalSimple_mean3_stderr.cs
+++ b/Catch22SharpTest/FC_LocalSimple_mean3_stderr.cs
@@ -8,7 +8,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void Test1()
         {
-            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.Test1, TestData.Test1.Length);
+            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.Test1);
             var expected = TestData.Test1Output["FC_LocalSimple_mean3_stderr"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -16,7 +16,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void Test2()
         {
-            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.Test2, TestData.Test2.Length);
+            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.Test2);
             var expected = TestData.Test2Output["FC_LocalSimple_mean3_stderr"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -24,7 +24,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void TestShort()
         {
-            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.TestShort, TestData.TestShort.Length);
+            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.TestShort);
             var expected = TestData.TestShortOutput["FC_LocalSimple_mean3_stderr"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -32,7 +32,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void TestSinusoid()
         {
-            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.TestSinusoid, TestData.TestSinusoid.Length);
+            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.TestSinusoid);
             var expected = TestData.TestSinusoidOutput["FC_LocalSimple_mean3_stderr"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }

--- a/Catch22SharpTest/MD_hrv_classic_pnn40.cs
+++ b/Catch22SharpTest/MD_hrv_classic_pnn40.cs
@@ -8,7 +8,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void Test1()
         {
-            var actual = Catch22.MD_hrv_classic_pnn40(TestData.Test1, TestData.Test1.Length);
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.Test1);
             var expected = TestData.Test1Output["MD_hrv_classic_pnn40"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -16,7 +16,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void Test2()
         {
-            var actual = Catch22.MD_hrv_classic_pnn40(TestData.Test2, TestData.Test2.Length);
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.Test2);
             var expected = TestData.Test2Output["MD_hrv_classic_pnn40"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -24,7 +24,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void TestShort()
         {
-            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestShort, TestData.TestShort.Length);
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestShort);
             var expected = TestData.TestShortOutput["MD_hrv_classic_pnn40"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
@@ -32,7 +32,7 @@ namespace Catch22SharpTest
         [TestMethod]
         public void TestSinusoid()
         {
-            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestSinusoid, TestData.TestSinusoid.Length);
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestSinusoid);
             var expected = TestData.TestSinusoidOutput["MD_hrv_classic_pnn40"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }


### PR DESCRIPTION
## Summary
- convert feature extractors and utilities to use ReadOnlySpan<T> for read-only data access
- drop redundant size parameters in Catch22 metrics in favor of Span.Length
- update unit tests to match the new method signatures

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db405907e48326b12e04f035f301a7