### PR TITLE
Port SB_BinaryStats to C# and add tests

### DIFF
--- a/Catch22Sharp/SB_BinaryStats.cs
+++ b/Catch22Sharp/SB_BinaryStats.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace Catch22Sharp
+{
+    public static partial class Catch22
+    {
+        public static double SB_BinaryStats_diff_longstretch0(ReadOnlySpan<double> y)
+        {
+            int size = y.Length;
+
+            // NaN check
+            for (int i = 0; i < size; i++)
+            {
+                if (double.IsNaN(y[i]))
+                {
+                    return double.NaN;
+                }
+            }
+
+            int[] yBin = new int[size - 1];
+            for (int i = 0; i < size - 1; i++)
+            {
+                double diffTemp = y[i + 1] - y[i];
+                yBin[i] = diffTemp < 0 ? 0 : 1;
+            }
+
+            int maxstretch0 = 0;
+            int last1 = 0;
+            for (int i = 0; i < size - 1; i++)
+            {
+                if (yBin[i] == 1 | i == size - 2)
+                {
+                    int stretch0 = i - last1;
+                    if (stretch0 > maxstretch0)
+                    {
+                        maxstretch0 = stretch0;
+                    }
+                    last1 = i;
+                }
+            }
+
+            return maxstretch0;
+        }
+
+        public static double SB_BinaryStats_mean_longstretch1(ReadOnlySpan<double> y)
+        {
+            int size = y.Length;
+
+            // NaN check
+            for (int i = 0; i < size; i++)
+            {
+                if (double.IsNaN(y[i]))
+                {
+                    return double.NaN;
+                }
+            }
+
+            int[] yBin = new int[size - 1];
+            double yMean = Stats.mean(y);
+            for (int i = 0; i < size - 1; i++)
+            {
+                yBin[i] = (y[i] - yMean <= 0) ? 0 : 1;
+            }
+
+            int maxstretch1 = 0;
+            int last1 = 0;
+            for (int i = 0; i < size - 1; i++)
+            {
+                if (yBin[i] == 0 | i == size - 2)
+                {
+                    int stretch1 = i - last1;
+                    if (stretch1 > maxstretch1)
+                    {
+                        maxstretch1 = stretch1;
+                    }
+                    last1 = i;
+                }
+            }
+
+            return maxstretch1;
+        }
+    }
+}

--- a/Catch22SharpTest/SB_BinaryStats_diff_longstretch0.cs
+++ b/Catch22SharpTest/SB_BinaryStats_diff_longstretch0.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class SB_BinaryStats_diff_longstretch0
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.SB_BinaryStats_diff_longstretch0(TestData.Test1);
+            var expected = TestData.Test1Output["SB_BinaryStats_diff_longstretch0"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.SB_BinaryStats_diff_longstretch0(TestData.Test2);
+            var expected = TestData.Test2Output["SB_BinaryStats_diff_longstretch0"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.SB_BinaryStats_diff_longstretch0(TestData.TestShort);
+            var expected = TestData.TestShortOutput["SB_BinaryStats_diff_longstretch0"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.SB_BinaryStats_diff_longstretch0(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["SB_BinaryStats_diff_longstretch0"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+    }
+}

--- a/Catch22SharpTest/SB_BinaryStats_mean_longstretch1.cs
+++ b/Catch22SharpTest/SB_BinaryStats_mean_longstretch1.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class SB_BinaryStats_mean_longstretch1
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.SB_BinaryStats_mean_longstretch1(TestData.Test1);
+            var expected = TestData.Test1Output["SB_BinaryStats_mean_longstretch1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.SB_BinaryStats_mean_longstretch1(TestData.Test2);
+            var expected = TestData.Test2Output["SB_BinaryStats_mean_longstretch1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.SB_BinaryStats_mean_longstretch1(TestData.TestShort);
+            var expected = TestData.TestShortOutput["SB_BinaryStats_mean_longstretch1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.SB_BinaryStats_mean_longstretch1(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["SB_BinaryStats_mean_longstretch1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port the SB_BinaryStats feature calculations from C to C#
- implement diff_longstretch0 and mean_longstretch1 using the shared stats helpers
- add regression tests for SB_BinaryStats_diff_longstretch0 and SB_BinaryStats_mean_longstretch1 across the standard datasets

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db4885d0608326b20f41f1783d8ea3