### PR TITLE
Port SB_TransitionMatrix feature and add tests

### DIFF
--- a/Catch22Sharp/SB_TransitionMatrix.cs
+++ b/Catch22Sharp/SB_TransitionMatrix.cs
@@ -1,0 +1,102 @@
+using System;
+
+namespace Catch22Sharp
+{
+    public static partial class Catch22
+    {
+        public static double SB_TransitionMatrix_3ac_sumdiagcov(ReadOnlySpan<double> y)
+        {
+            int size = y.Length;
+
+            bool constant = true;
+            double first = y[0];
+            for (int i = 0; i < size; i++)
+            {
+                double value = y[i];
+                if (double.IsNaN(value))
+                {
+                    return double.NaN;
+                }
+
+                if (value != first)
+                {
+                    constant = false;
+                }
+            }
+
+            if (constant)
+            {
+                return double.NaN;
+            }
+
+            const int numGroups = 3;
+
+            int tau = co_firstzero(y);
+
+            double[] yFilt = new double[size];
+            for (int i = 0; i < size; i++)
+            {
+                yFilt[i] = y[i];
+            }
+
+            int nDown = (size - 1) / tau + 1;
+            double[] yDown = new double[nDown];
+            for (int i = 0; i < nDown; i++)
+            {
+                yDown[i] = yFilt[i * tau];
+            }
+
+            int[] yCG = new int[nDown];
+            sb_coarsegrain(yDown, "quantile", numGroups, yCG);
+
+            double[,] T = new double[numGroups, numGroups];
+            for (int j = 0; j < nDown - 1; j++)
+            {
+                int from = yCG[j] - 1;
+                int to = yCG[j + 1] - 1;
+                T[from, to] += 1.0;
+            }
+
+            double normalizer = nDown - 1;
+            for (int i = 0; i < numGroups; i++)
+            {
+                for (int j = 0; j < numGroups; j++)
+                {
+                    T[i, j] /= normalizer;
+                }
+            }
+
+            double[][] columns = new double[numGroups][];
+            for (int i = 0; i < numGroups; i++)
+            {
+                columns[i] = new double[numGroups];
+            }
+
+            for (int i = 0; i < numGroups; i++)
+            {
+                columns[0][i] = T[i, 0];
+                columns[1][i] = T[i, 1];
+                columns[2][i] = T[i, 2];
+            }
+
+            double[,] COV = new double[numGroups, numGroups];
+            for (int i = 0; i < numGroups; i++)
+            {
+                for (int j = i; j < numGroups; j++)
+                {
+                    double covTemp = Stats.cov(columns[i], columns[j]);
+                    COV[i, j] = covTemp;
+                    COV[j, i] = covTemp;
+                }
+            }
+
+            double sumdiagcov = 0.0;
+            for (int i = 0; i < numGroups; i++)
+            {
+                sumdiagcov += COV[i, i];
+            }
+
+            return sumdiagcov;
+        }
+    }
+}

--- a/Catch22Sharp/butterworth.cs
+++ b/Catch22Sharp/butterworth.cs
@@ -1,0 +1,119 @@
+//
+//  butterworth.cs
+//
+//  Ported from butterworth.c
+//  Created by Carl Henning Lubba on 23/09/2018.
+//
+
+using System;
+using System.Numerics;
+
+namespace Catch22Sharp
+{
+    internal static class Butterworth
+    {
+        public static void poly(ReadOnlySpan<Complex> x, Span<Complex> @out)
+        {
+            int size = x.Length;
+
+            // initialise
+            @out[0] = Complex.One;
+            for (int i = 1; i < size + 1; i++)
+            {
+                @out[i] = Complex.Zero;
+            }
+
+            Complex[] outTempArray = new Complex[size + 1];
+            Span<Complex> outTemp = outTempArray.AsSpan();
+            Span<Complex> outSpan = @out.Slice(0, size + 1);
+
+            for (int i = 1; i < size + 1; i++)
+            {
+                outSpan.CopyTo(outTemp);
+
+                for (int j = 1; j < i + 1; j++)
+                {
+                    Complex temp1 = x[i - 1] * outTemp[j - 1];
+                    Complex temp2 = @out[j];
+                    @out[j] = temp2 - temp1;
+                }
+            }
+        }
+
+        public static void filt(ReadOnlySpan<double> y, ReadOnlySpan<double> a, ReadOnlySpan<double> b, Span<double> @out)
+        {
+            /* Filter a signal y with the filter coefficients a and b, output to array out.*/
+
+            double offset = y[0];
+            int size = y.Length;
+            int nCoeffs = a.Length;
+
+            for (int i = 0; i < size; i++)
+            {
+                @out[i] = 0;
+                for (int j = 0; j < nCoeffs; j++)
+                {
+                    if (i - j >= 0)
+                    {
+                        @out[i] += b[j] * (y[i - j] - offset);
+                        @out[i] -= a[j] * @out[i - j];
+                    }
+                }
+            }
+
+            for (int i = 0; i < size; i++)
+            {
+                @out[i] += offset;
+            }
+        }
+
+        public static void reverse_array(Span<double> a)
+        {
+            /* Reverse the order of the elements in an array. Write back into the input array.*/
+
+            int size = a.Length;
+            double temp;
+            for (int i = 0; i < size / 2; i++)
+            {
+                temp = a[i];
+                a[i] = a[size - i - 1];
+                a[size - 1 - i] = temp;
+            }
+        }
+
+        public static void filt_reverse(ReadOnlySpan<double> y, ReadOnlySpan<double> a, ReadOnlySpan<double> b, Span<double> @out)
+        {
+            /* Filter a signal y with the filter coefficients a and b _in reverse order_, output to array out.*/
+
+            int size = y.Length;
+
+            double[] yTempArray = y.ToArray();
+            Span<double> yTemp = yTempArray.AsSpan();
+
+            reverse_array(yTemp);
+
+            double offset = yTemp[0];
+            int nCoeffs = a.Length;
+
+            for (int i = 0; i < size; i++)
+            {
+                @out[i] = 0;
+                for (int j = 0; j < nCoeffs; j++)
+                {
+                    if (i - j >= 0)
+                    {
+                        @out[i] += b[j] * (yTemp[i - j] - offset);
+                        @out[i] -= a[j] * @out[i - j];
+                    }
+                }
+            }
+
+            for (int i = 0; i < size; i++)
+            {
+                @out[i] += offset;
+            }
+
+            reverse_array(@out);
+        }
+    }
+}

--- a/Catch22SharpTest/SB_TransitionMatrix_3ac_sumdiagcov.cs
+++ b/Catch22SharpTest/SB_TransitionMatrix_3ac_sumdiagcov.cs
@@ -1,0 +1,40 @@
+using Catch22Sharp;
+
+namespace Catch22SharpTest
+{
+    [TestClass]
+    public class SB_TransitionMatrix_3ac_sumdiagcov
+    {
+        [TestMethod]
+        public void Test1()
+        {
+            var actual = Catch22.SB_TransitionMatrix_3ac_sumdiagcov(TestData.Test1);
+            var expected = TestData.Test1Output["SB_TransitionMatrix_3ac_sumdiagcov"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void Test2()
+        {
+            var actual = Catch22.SB_TransitionMatrix_3ac_sumdiagcov(TestData.Test2);
+            var expected = TestData.Test2Output["SB_TransitionMatrix_3ac_sumdiagcov"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestShort()
+        {
+            var actual = Catch22.SB_TransitionMatrix_3ac_sumdiagcov(TestData.TestShort);
+            var expected = TestData.TestShortOutput["SB_TransitionMatrix_3ac_sumdiagcov"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestSinusoid()
+        {
+            var actual = Catch22.SB_TransitionMatrix_3ac_sumdiagcov(TestData.TestSinusoid);
+            var expected = TestData.TestSinusoidOutput["SB_TransitionMatrix_3ac_sumdiagcov"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port the SB_TransitionMatrix_3ac_sumdiagcov calculation into the C# Catch22 helper set
- add unit tests covering the transition matrix feature against the reference datasets

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db5a9dee288326b73a6fe5d6a3d892