### PR TITLE
Add argument validation to Catch22 indexers

### DIFF
--- a/Catch22Sharp/Catch22.cs
+++ b/Catch22Sharp/Catch22.cs
@@ -96,14 +96,41 @@ namespace Catch22Sharp
         }
 
         /// <inheritdoc/>
-        public double this[int index] => values[index];
+        public double this[int index]
+        {
+            get
+            {
+                if ((uint)index >= (uint)values.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return values[index];
+            }
+        }
 
         /// <summary>
         /// Retrieves the feature value identified by the specified feature name.
         /// </summary>
         /// <param name="featureName">The canonical or short feature identifier.</param>
         /// <returns>The computed feature value.</returns>
-        public double this[string featureName] => values[nameToIndex[featureName]];
+        public double this[string featureName]
+        {
+            get
+            {
+                if (featureName is null)
+                {
+                    throw new ArgumentNullException(nameof(featureName));
+                }
+
+                if (!nameToIndex.TryGetValue(featureName, out var featureIndex))
+                {
+                    throw new ArgumentException($"Unknown feature name: {featureName}", nameof(featureName));
+                }
+
+                return values[featureIndex];
+            }
+        }
 
         /// <inheritdoc/>
         public IEnumerator<double> GetEnumerator()


### PR DESCRIPTION
## Summary
- add bounds checking to the integer indexer to guard against invalid positions
- validate feature names in the string indexer, including null handling and unknown names

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db6fd1cd188326a073d5800033e565