### PR TITLE
Add XML documentation comments for Catch22Ex extension

### DIFF
--- a/Catch22Sharp/Catch22Ex.cs
+++ b/Catch22Sharp/Catch22Ex.cs
@@ -4,8 +4,18 @@ using System.Linq;
 
 namespace Catch22Sharp
 {
+    /// <summary>
+    /// Provides extension methods that create <see cref="Catch22"/> analyzers for
+    /// numeric sequences.
+    /// </summary>
     public static class Catch22Ex
     {
+        /// <summary>
+        /// Creates a <see cref="Catch22"/> instance from the specified sequence so its
+        /// statistical features can be computed.
+        /// </summary>
+        /// <param name="y">The time-series data to analyze.</param>
+        /// <returns>The <see cref="Catch22"/> analyzer for the provided data.</returns>
         public static Catch22 Catch22(this IEnumerable<double> y)
         {
             return new Catch22(y.ToArray());


### PR DESCRIPTION
## Summary
- add XML documentation for the `Catch22Ex` extension class
- document the `Catch22` extension method and its parameter

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68db7d3505e8832695934f8a5a72f8ce