### PR TITLE
Add random and wave tests to all feature unit tests

### DIFF
--- a/Catch22SharpTest/CO_Embed2_Dist_tau_d_expfit_meandiff.cs
+++ b/Catch22SharpTest/CO_Embed2_Dist_tau_d_expfit_meandiff.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["CO_Embed2_Dist_tau_d_expfit_meandiff"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.CO_Embed2_Dist_tau_d_expfit_meandiff(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["CO_Embed2_Dist_tau_d_expfit_meandiff"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.CO_Embed2_Dist_tau_d_expfit_meandiff(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["CO_Embed2_Dist_tau_d_expfit_meandiff"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/CO_FirstMin_ac.cs
+++ b/Catch22SharpTest/CO_FirstMin_ac.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["CO_FirstMin_ac"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.CO_FirstMin_ac(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["CO_FirstMin_ac"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.CO_FirstMin_ac(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["CO_FirstMin_ac"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/CO_HistogramAMI_even_2_5.cs
+++ b/Catch22SharpTest/CO_HistogramAMI_even_2_5.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["CO_HistogramAMI_even_2_5"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.CO_HistogramAMI_even_2_5(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["CO_HistogramAMI_even_2_5"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.CO_HistogramAMI_even_2_5(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["CO_HistogramAMI_even_2_5"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/CO_f1ecac.cs
+++ b/Catch22SharpTest/CO_f1ecac.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["CO_f1ecac"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.CO_f1ecac(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["CO_f1ecac"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.CO_f1ecac(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["CO_f1ecac"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/CO_trev_1_num.cs
+++ b/Catch22SharpTest/CO_trev_1_num.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["CO_trev_1_num"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.CO_trev_1_num(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["CO_trev_1_num"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.CO_trev_1_num(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["CO_trev_1_num"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/DN_HistogramMode_10.cs
+++ b/Catch22SharpTest/DN_HistogramMode_10.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["DN_HistogramMode_10"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.DN_HistogramMode_10(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["DN_HistogramMode_10"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.DN_HistogramMode_10(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["DN_HistogramMode_10"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/DN_OutlierInclude_n_001_mdrmd.cs
+++ b/Catch22SharpTest/DN_OutlierInclude_n_001_mdrmd.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["DN_OutlierInclude_n_001_mdrmd"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.DN_OutlierInclude_n_001_mdrmd(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["DN_OutlierInclude_n_001_mdrmd"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.DN_OutlierInclude_n_001_mdrmd(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["DN_OutlierInclude_n_001_mdrmd"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/DN_OutlierInclude_p_001_mdrmd.cs
+++ b/Catch22SharpTest/DN_OutlierInclude_p_001_mdrmd.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["DN_OutlierInclude_p_001_mdrmd"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.DN_OutlierInclude_p_001_mdrmd(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["DN_OutlierInclude_p_001_mdrmd"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.DN_OutlierInclude_p_001_mdrmd(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["DN_OutlierInclude_p_001_mdrmd"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/FC_LocalSimple_mean1_tauresrat.cs
+++ b/Catch22SharpTest/FC_LocalSimple_mean1_tauresrat.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["FC_LocalSimple_mean1_tauresrat"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["FC_LocalSimple_mean1_tauresrat"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.FC_LocalSimple_mean1_tauresrat(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["FC_LocalSimple_mean1_tauresrat"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/FC_LocalSimple_mean3_stderr.cs
+++ b/Catch22SharpTest/FC_LocalSimple_mean3_stderr.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["FC_LocalSimple_mean3_stderr"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["FC_LocalSimple_mean3_stderr"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.FC_LocalSimple_mean3_stderr(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["FC_LocalSimple_mean3_stderr"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/IN_AutoMutualInfoStats_40_gaussian_fmmi.cs
+++ b/Catch22SharpTest/IN_AutoMutualInfoStats_40_gaussian_fmmi.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["IN_AutoMutualInfoStats_40_gaussian_fmmi"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.IN_AutoMutualInfoStats_40_gaussian_fmmi(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["IN_AutoMutualInfoStats_40_gaussian_fmmi"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.IN_AutoMutualInfoStats_40_gaussian_fmmi(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["IN_AutoMutualInfoStats_40_gaussian_fmmi"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/MD_hrv_classic_pnn40.cs
+++ b/Catch22SharpTest/MD_hrv_classic_pnn40.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["MD_hrv_classic_pnn40"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["MD_hrv_classic_pnn40"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.MD_hrv_classic_pnn40(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["MD_hrv_classic_pnn40"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/PD_PeriodicityWang_th0_01.cs
+++ b/Catch22SharpTest/PD_PeriodicityWang_th0_01.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["PD_PeriodicityWang_th0_01"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.PD_PeriodicityWang_th0_01(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["PD_PeriodicityWang_th0_01"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.PD_PeriodicityWang_th0_01(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["PD_PeriodicityWang_th0_01"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SB_BinaryStats_diff_longstretch0.cs
+++ b/Catch22SharpTest/SB_BinaryStats_diff_longstretch0.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SB_BinaryStats_diff_longstretch0"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SB_BinaryStats_diff_longstretch0(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SB_BinaryStats_diff_longstretch0"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SB_BinaryStats_diff_longstretch0(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SB_BinaryStats_diff_longstretch0"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SB_BinaryStats_mean_longstretch1.cs
+++ b/Catch22SharpTest/SB_BinaryStats_mean_longstretch1.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SB_BinaryStats_mean_longstretch1"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SB_BinaryStats_mean_longstretch1(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SB_BinaryStats_mean_longstretch1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SB_BinaryStats_mean_longstretch1(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SB_BinaryStats_mean_longstretch1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SB_MotifThree_quantile_hh.cs
+++ b/Catch22SharpTest/SB_MotifThree_quantile_hh.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SB_MotifThree_quantile_hh"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SB_MotifThree_quantile_hh(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SB_MotifThree_quantile_hh"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SB_MotifThree_quantile_hh(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SB_MotifThree_quantile_hh"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SB_TransitionMatrix_3ac_sumdiagcov.cs
+++ b/Catch22SharpTest/SB_TransitionMatrix_3ac_sumdiagcov.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SB_TransitionMatrix_3ac_sumdiagcov"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SB_TransitionMatrix_3ac_sumdiagcov(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SB_TransitionMatrix_3ac_sumdiagcov"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SB_TransitionMatrix_3ac_sumdiagcov(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SB_TransitionMatrix_3ac_sumdiagcov"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SC_FluctAnal_2_dfa_50_1_2_logi_prop_r1.cs
+++ b/Catch22SharpTest/SC_FluctAnal_2_dfa_50_1_2_logi_prop_r1.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SC_FluctAnal_2_dfa_50_1_2_logi_prop_r1"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SC_FluctAnal_2_dfa_50_1_2_logi_prop_r1(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SC_FluctAnal_2_dfa_50_1_2_logi_prop_r1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SC_FluctAnal_2_dfa_50_1_2_logi_prop_r1(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SC_FluctAnal_2_dfa_50_1_2_logi_prop_r1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SC_FluctAnal_2_rsrangefit_50_1_logi_prop_r1.cs
+++ b/Catch22SharpTest/SC_FluctAnal_2_rsrangefit_50_1_logi_prop_r1.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SC_FluctAnal_2_rsrangefit_50_1_logi_prop_r1"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SC_FluctAnal_2_rsrangefit_50_1_logi_prop_r1(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SC_FluctAnal_2_rsrangefit_50_1_logi_prop_r1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SC_FluctAnal_2_rsrangefit_50_1_logi_prop_r1(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SC_FluctAnal_2_rsrangefit_50_1_logi_prop_r1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SP_Summaries_welch_rect_area_5_1.cs
+++ b/Catch22SharpTest/SP_Summaries_welch_rect_area_5_1.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SP_Summaries_welch_rect_area_5_1"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SP_Summaries_welch_rect_area_5_1(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SP_Summaries_welch_rect_area_5_1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SP_Summaries_welch_rect_area_5_1(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SP_Summaries_welch_rect_area_5_1"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }

--- a/Catch22SharpTest/SP_Summaries_welch_rect_centroid.cs
+++ b/Catch22SharpTest/SP_Summaries_welch_rect_centroid.cs
@@ -36,5 +36,21 @@ namespace Catch22SharpTest
             var expected = TestData.TestSinusoidOutput["SP_Summaries_welch_rect_centroid"];
             Assert.AreEqual(expected, actual, 1.0E-6);
         }
+
+        [TestMethod]
+        public void TestRandom()
+        {
+            var actual = Catch22.SP_Summaries_welch_rect_centroid(TestData.TestRandom);
+            var expected = TestData.TestRandomOutput["SP_Summaries_welch_rect_centroid"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
+
+        [TestMethod]
+        public void TestWave()
+        {
+            var actual = Catch22.SP_Summaries_welch_rect_centroid(TestData.TestWave);
+            var expected = TestData.TestWaveOutput["SP_Summaries_welch_rect_centroid"];
+            Assert.AreEqual(expected, actual, 1.0E-6);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add TestRandom and TestWave coverage to each feature-specific test class to mirror the updated DN_HistogramMode_5 suite

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68dbd96bb054832683dbda4ab4c848a0